### PR TITLE
Set up mise, prek, and pre-commit hooks for cloud agent development

### DIFF
--- a/.claude/skills/review-pr-comments/SKILL.md
+++ b/.claude/skills/review-pr-comments/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: review-pr-comments
+description: >-
+  Processes review comments on the open PR for the current branch. Fixes real
+  issues in code; updates .github/instructions/ to prevent low-quality comments
+  from recurring.
+when_to_use: >-
+  Use when the user says "review PR comments", "look at PR feedback", "review
+  copilot comments", or invokes this skill by name. Always invoke this skill
+  before manually reading PR comments yourself.
+user-invocable: true
+allowed-tools: Bash(gh *) Bash(python3 *) Bash(git *) Bash(grep *)
+---
+
+# Review PR Comments
+
+Processes review comments on the open PR for the current branch. Fixes real issues in code; improves `.github/instructions/` to prevent low-quality comments from recurring.
+
+**This skill has two hard approval gates:**
+1. **Action plan gate** — present the full plan and wait for explicit approval before touching any files.
+2. **Commit gate** — show the full diff and ask "Approve to commit?" before committing or pushing. This gate fires every time, even if the user approved the action plan.
+
+## Fetch Comments
+
+Get the PR number first:
+```bash
+gh pr view --json number,url
+```
+If no open PR exists for the current branch, tell the user and stop.
+
+Fetch all review threads (paginating past 100 if needed) using GraphQL, retrieving up to 100 comments per thread so human replies to bot comments are visible. Before filtering threads, the script also fetches the PR's deleted files so threads on deleted paths are skipped, and skips resolved and outdated threads.
+
+Run the bundled [fetch_threads.py](./fetch_threads.py) script from this skill's base directory. It derives `owner`, `repo`, and `number` from `gh` automatically.
+
+The script prints `owner=... repo=... number=...` on the first line — save those values to substitute into the `{owner}/{repo}/{number}` placeholders used in later commands.
+
+Also fetch top-level review summaries from bots:
+```bash
+gh api repos/{owner}/{repo}/pulls/{number}/reviews \
+  | python3 -c "
+import json, sys
+for r in json.load(sys.stdin):
+    if r['user']['type'] == 'Bot' and r.get('body'):
+        print(r['user']['login'], r['state'], r['body'][:300])
+"
+```
+
+## Identify and Triage Comments
+
+A comment is agent-sourced when `author.__typename == "Bot"` (GraphQL) or `user.type == "Bot"` (REST). These are different fields in different API responses — apply the correct check for each source.
+
+Human comments: fix the issue if it's valid. If not, surface them to the user verbatim without acting.
+
+**Human replies inside bot-opened threads carry the highest priority.** When a human has replied to a bot thread, treat the human's position as authoritative: if they say the issue is real, fix it even if you would otherwise dismiss the bot comment; if they say it's intentional or fine, surface it as a human dismissal. Always show human replies to the user verbatim in the action plan.
+
+If a comment is stale — the issue was already fixed in a prior commit on this branch — and has no human replies, resolve the thread silently and exclude it from the action plan. If it has human replies, surface those verbatim per the human reply rule above.
+
+## Evaluate Each Comment
+
+**Before triaging any comment, run this checklist:**
+
+1. **Verify the claim in full file context, not just the diff hunk.** If the comment says "X is not imported", "Y is not loaded", or "Z will not work" — read the complete file, not just the changed lines. Do not accept the claim if `import X`, the CDN link, or the config value appears elsewhere in the file or in another file the diff touches.
+
+2. **Search for the same pattern before accepting any "broken" or "incorrect" claim.** Run `grep -r "flagged-pattern" --include="*.ext" -l` across the codebase. If the same pattern exists in other files and CI is passing, the pattern is established — dismiss the comment. Write the instructions rule as a prerequisite, not a prohibition: "Before flagging X, check whether it already appears elsewhere in the project" — not "do not flag X in file Y". This makes the reviewer do the verification work first.
+
+3. **Require evidence for any remaining "broken" claim.** If the pattern is new or the reviewer still claims breakage after checking, require them to supply all three before the claim is actionable: the specific error it produces, the steps to reproduce it, and the linter rule or CI check that would catch it. Write an instructions update stating these requirements.
+
+4. **Distinguish "not the recommended pattern" from "broken".** A pattern that deviates from a framework's documented ideal but produces correct behavior is not a bug. Only treat something as broken if you can state the specific user-visible failure and the exact inputs that trigger it.
+
+5. **Deduplicate before acting.** If a comment is the third (or fifth, or eighth) thread flagging the same issue in this PR, it is a duplicate. Fix the issue once, resolve all duplicate threads together, and add an instructions rule to prevent recurrence. Do not handle each thread individually.
+
+6. **Check branch context.** On `ui/framework-*` evaluation branches, the goal is assessing UI behavior and developer experience, not production optimization. Do not flag tree-shaking, bundle size, wildcard imports, or "not the recommended pattern" concerns on these branches.
+
+---
+
+**Fix the code if the comment identifies:**
+- A real bug, logic error, or security issue
+- Invalid markup that affects rendering or accessibility
+- Dead code — unused, unreachable, or unwired methods/variables
+- A correctness issue with the language/framework (wrong key type, invalid nesting, broken API usage)
+
+**When a comment claims code is broken or has a bug:**
+1. Check whether an existing test already asserts on the claimed behavior. If one does, the comment is dismissed as incorrect — update `.github/instructions/` to tell the reviewer to check for existing tests before claiming breakage.
+2. If no test covers it and the bug is real, fix the code AND add a test that would have caught it.
+3. If no test covers it but the bug claim is wrong, add a test that demonstrates the code works correctly, then dismiss via instructions update (see checklist item 3 for what the rule must require).
+
+**Update `.github/instructions/` if the comment:**
+- Is a style preference with no correctness impact
+- Recommends patterns inconsistent with how the codebase is already written
+- Flags intentional decisions that are consistent throughout the codebase
+- Repeats the same point across multiple instances of an established pattern
+- Is factually wrong, misreads the diff, or points to a non-existent issue — update instructions to prevent that **class** of comment from recurring, not just the specific instance
+- Is too vague to produce an actionable change — update instructions to require specificity
+- Flags a pattern already caught by an existing CI or linter check — CI enforcement is sufficient; a prose rule is redundant
+- Flags a style, formatting, or linting concern not currently caught by CI — the right fix is adding a CI/linter rule, not a manual documentation rule; update instructions to direct the reviewer to propose a CI addition instead of a code review comment
+
+**Instructions updates must address the root cause, not the symptom.** The fix should eliminate that entire class of comment going forward — not suppress a specific file or pattern instance. Test: would a reviewer with no PR history still make the comment after reading the rule? If yes, the rule is too narrow. Prefer prerequisites ("before flagging X, verify Y") over prohibitions ("do not flag X in file Z").
+
+**A comment can require both a code fix and an instructions update.** For example, a comment may correctly identify one real issue while also making a factually wrong claim (e.g. flagging valid syntax as an error). In that case: fix the real issue in code AND add an instructions rule to suppress the wrong claim in future reviews.
+
+## Plan and Present — Wait for Approval to Apply
+
+**Before touching any files**, present the full action plan to the user:
+
+```
+## PR Comment Action Plan
+
+**Fix in code:**
+- `src/foo.vue` — [one-line description of what and why]
+
+**Update .github/instructions/:**
+- `vue.instructions.md` (applyTo: src/**/*.vue) — add rule: [exact rule text]
+
+**Human comments requiring your attention:**
+- [verbatim quote, file:line]
+```
+
+Only include sections that have content. Omit any section with nothing to report.
+
+**Wait for explicit user approval before making any changes.** End your response with the explicit question: **"Approve to apply?"** This is Gate 1. It covers only applying the fixes listed above — it does not cover committing or pushing. Do not proceed until the user confirms.
+
+## Apply Fixes
+
+Once approved, apply changes in this order:
+
+1. **Code fixes**: read the file and surrounding context. Apply the minimum surgical change. When addressing a valid comment, consider why it slipped through — then generalize: scan all code being introduced in this PR for the same class of issue and fix every instance in the same pass. Do not patch only the reported line.
+
+   **Every code fix must be accompanied by a test, or an explicit written justification for why a test is not needed.** Acceptable reasons to skip a test: the behavior is untestable in jsdom (e.g. browser lifecycle hooks with no observable side effect), or an existing test already covers the corrected behavior. If you skip a test, state the reason in the action plan and in the commit message. Do not silently omit tests.
+
+   After applying each fix, check for side effects: identify all callers and consumers of the changed code and verify they still behave correctly with the new output. A fix that changes the shape or size of a data structure (e.g., adding entries to an exported array) must be followed by a scan of every place that structure is consumed in the PR diff. This is the most common source of second review cycles — the fix is correct in isolation but breaks a consumer.
+
+2. **Instruction updates**: follow the naming and frontmatter conventions already present in the repo:
+   - File names: `<topic>.instructions.md` — e.g. `review.instructions.md`, `vue.instructions.md`, `javascript.instructions.md`
+   - Frontmatter: `applyTo:` scoped to the relevant file glob — e.g. `"src/**/*.vue"`, `"**/*.js,**/*.mjs"`, `"**"` for repo-wide
+   - Scope `applyTo` to match the type of file the comment was about — do not use `"**"` when a narrower glob fits
+   - For review-only rules, add `excludeAgent: "cloud-agent"` so they apply to Copilot code review but not the coding agent
+   - Rules must be specific and concrete:
+     - Good: `- Do not comment on import ordering — the project does not enforce a specific order.`
+     - Bad: `- Don't comment on style.`
+   - If no `.github/instructions/` directory exists, create one with a scoped `review.instructions.md`.
+3. **Run lint and tests** after ALL changes (code fixes + instruction
+   updates) are applied. Do not proceed to the next step until they
+   pass. If any file was modified since the last test run, rerun.
+
+4. **Accuracy audit of changed code and surrounding context.** For every file modified in this skill run, read the current state of the file and check:
+   - Inline comments and doc comments that reference the changed code: do they still describe what the code actually does?
+   - Comments that reference line numbers, method names, variable names, or behavior that was altered: update them to match reality.
+   - Any test descriptions (`it(...)`, `describe(...)`, assertion messages) that describe the behavior under test: confirm they still match what the code does.
+   - Any README or `.github/instructions/` content that documents the changed behavior: verify it is still accurate and update if not.
+   - Dead comments: comments that described a previous approach and no longer apply. Remove them.
+
+   This step is about internal consistency. It is not a code review. Do not introduce new logic — only fix stale prose and comments.
+
+## Self-Review Pass — Anticipate the Next Cycle
+
+After all reactive fixes are applied and tests pass, perform a pre-flight self-review of the **full PR diff** to catch anything a future bot review would flag, before the push triggers another cycle.
+
+```bash
+gh pr view --json baseRefName --jq '.baseRefName'
+# then:
+git diff origin/<base>...HEAD
+```
+
+Load every file in `.github/instructions/` and match each file's `applyTo` glob against the changed files in the diff. For each changed file, apply the rules from every matching instructions file as if you are the reviewer.
+
+For each potential finding, apply the same triage logic as the **Evaluate Each Comment** section above.
+
+**Mandatory proactive checks** — run these explicitly on the full diff, every time:
+
+1. **Em-dashes.** Run `grep -rn " — " <all files touched by the diff>`. Fix every instance found. This is the single most common source of repeat bot comments. Do not rely on memory or the reviewer to catch them.
+
+2. **Clickable elements without keyboard accessibility.** For every element introduced in the diff that has a click handler, verify it is keyboard reachable and has a visible or programmatic label. The specific requirements vary by framework — check the project's existing conventions for how interactive non-button elements are made accessible (e.g., native button, role, tabindex, framework-specific props). Flag every element that diverges from that pattern and fix all instances in the same pass.
+
+3. **Lint with a clean cache.** Before presenting the final diff, run the project's lint command with any caches cleared if the project uses a build-tool-integrated linter. Stale caches from other branches can produce false positives or suppress real errors.
+
+4. **Conflict resolution completeness.** If this skill run involved resolving merge conflicts, run lint immediately after resolution before doing anything else. Conflict markers can leave structurally broken templates that pass a visual check but fail the parser.
+
+The goal is: after this push, no new bot comment should appear for code that was already in the diff before this commit.
+
+## ⛔ STOP — Present Changes and Wait for Approval to Commit (Gate 2)
+
+Include proactive self-review findings in the summary, clearly labeled **Proactive (self-review)**, so the user can distinguish them from reactive fixes.
+
+**YOU MUST END YOUR RESPONSE HERE** with the diff summary and the explicit question: **"Approve to commit?"** This is Gate 2. Do not write any further tool calls or prose after asking. Do not commit, push, or resolve threads in this same response. Wait for the user's next message.
+
+Once the user explicitly approves Gate 2 (e.g. "commit it", "yes", "ship it", "y", "approved"), commit all changed source and instructions files together in the *next* response. Write a commit message naming which comments were fixed in code and which were handled by updating instructions. Push to the PR branch. Then in that same response, continue with the remaining steps in order: audit the PR title and description, resolve bot threads, and request re-review.
+
+**Approval covers only the gate it was given for, and only the exact diff shown at that moment.**
+- Approving Gate 1 ("Approve to apply?") means: go apply the listed fixes. It is not approval to commit.
+- Approving Gate 2 ("Approve to commit?") means: commit exactly the diff shown. If any file changes after Gate 2 approval — for any reason — stop, show the new diff, and ask "Approve to commit?" again.
+- Do not carry approval forward across gates or across independent changes.
+
+**This is a hard gate — not a soft suggestion.** Do not treat any response as Gate 2 approval unless it comes *after* you have shown the full diff of changes made and explicitly asked "Approve to commit?".
+
+## Audit PR Title and Description
+
+Before requesting re-review, fetch the current PR title and body and check them against the actual state of the diff:
+
+```bash
+gh pr view --json title,body --jq '"Title: " + .title + "\n\nBody:\n" + .body'
+```
+
+Compare each claim in the title and body against `git diff origin/<base>...HEAD`. Flag any:
+- Features or behaviors claimed that are no longer present or were changed
+- Implementation details (component names, method names, file paths) that were renamed or removed
+- Scope descriptions that no longer match the actual files changed
+
+Update the PR title and/or body if inaccuracies are found:
+```bash
+gh pr edit --title "Accurate title" --body "Updated description"
+```
+
+Do this step silently — only surface changes to the user if the title or body required correction.
+
+## Resolve Bot Threads
+
+The thread IDs were already fetched above. For each unresolved bot thread that was addressed (fixed in code or handled via instructions), resolve it:
+
+```bash
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: { threadId: "{thread_id}" }) {
+    thread { isResolved }
+  }
+}'
+```
+
+Never resolve threads where the first comment's author is a human. Never resolve a bot-opened thread that has human replies — those require the user's attention.
+
+## Request Re-review
+
+After resolving threads, re-request a Copilot review via GraphQL. The REST API and `gh pr edit --add-reviewer` don't support bots, but the GraphQL `requestReviews` mutation has a `botIds` field that does — including re-requesting after a bot has already reviewed.
+
+Step 1 — get the PR node ID:
+```bash
+gh api graphql -f query='
+query {
+  repository(owner: "{owner}", name: "{repo}") {
+    pullRequest(number: {number}) { id }
+  }
+}'
+```
+
+Step 2 — request the review:
+```bash
+gh api graphql -f query='
+mutation {
+  requestReviews(input: {
+    pullRequestId: "{pr_node_id}",
+    botIds: ["BOT_kgDOCnlnWA"]
+  }) {
+    pullRequest {
+      reviewRequests(first: 100) {
+        nodes { requestedReviewer { ... on Bot { login } } }
+      }
+    }
+  }
+}'
+```
+
+`BOT_kgDOCnlnWA` is the node ID for `copilot-pull-request-reviewer` on github.com. If it ever needs to be re-derived: `gh api /users/copilot-pull-request-reviewer --jq .node_id`. If the mutation returns the bot login in `reviewRequests`, the re-request succeeded.

--- a/.claude/skills/review-pr-comments/fetch_threads.py
+++ b/.claude/skills/review-pr-comments/fetch_threads.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Fetch unresolved, current PR review threads for the current branch.
+
+Prints each thread's author, file, line, thread ID, comment body (truncated
+to 300 chars), and any human replies. Output is consumed by the
+review-pr-comments skill to triage and act on bot review comments.
+"""
+import json
+import subprocess
+import sys
+
+
+def run(cmd):
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        sys.exit(f'Command failed: {" ".join(cmd)}\n{r.stderr}')
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError as e:
+        sys.exit(f'Failed to parse response from {" ".join(cmd)}: {e}\n{r.stdout[:200]}')
+
+
+def fetch_deleted_paths(owner, repo, number):
+    """Return the set of filenames deleted in this PR."""
+    all_files = []
+    page = 1
+    while True:
+        batch = run(['gh', 'api', f'repos/{owner}/{repo}/pulls/{number}/files?per_page=100&page={page}'])
+        all_files.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return {f.get('filename') for f in all_files if f.get('status') == 'removed' and f.get('filename')}
+
+
+def fetch_threads(owner, repo, number):
+    """Fetch all review threads for the PR, paginating past 100."""
+    cursor = None
+    all_threads = []
+    while True:
+        after_arg = f', after: "{cursor}"' if cursor else ''
+        query = f'''
+query {{
+  repository(owner: "{owner}", name: "{repo}") {{
+    pullRequest(number: {number}) {{
+      reviewThreads(first: 100{after_arg}) {{
+        pageInfo {{ hasNextPage endCursor }}
+        nodes {{
+          id
+          isResolved
+          isOutdated
+          comments(first: 100) {{
+            nodes {{
+              path
+              line
+              body
+              author {{ login __typename }}
+            }}
+          }}
+        }}
+      }}
+    }}
+  }}
+}}'''
+        data = run(['gh', 'api', 'graphql', '-f', f'query={query.strip()}'])
+        if 'errors' in data:
+            sys.exit('GraphQL errors: ' + json.dumps(data['errors']))
+        pr = data.get('data', {}).get('repository', {}).get('pullRequest')
+        if not pr:
+            sys.exit('PR not found or insufficient permissions')
+        rt = pr.get('reviewThreads', {})
+        all_threads.extend(rt.get('nodes') or [])
+        pi = rt.get('pageInfo', {})
+        if not pi.get('hasNextPage'):
+            break
+        cursor = pi.get('endCursor')
+    return all_threads
+
+
+def print_threads(all_threads, deleted):
+    """Print unresolved, current threads not on deleted paths."""
+    for t in all_threads:
+        if not t or t.get('isResolved') or t.get('isOutdated'):
+            continue
+        all_comments = t.get('comments', {}).get('nodes') or []
+        if not all_comments:
+            continue
+        c = all_comments[0]
+        path = c.get('path') or ''
+        if path in deleted:
+            continue
+        author = c.get('author') or {}
+        print(f"[{author.get('login', 'unknown')} / {author.get('__typename', 'unknown')}] {path}:{c.get('line')} thread:{t.get('id')}")
+        print(c.get('body', '')[:300])
+        human_replies = [
+            r for r in all_comments[1:]
+            if (r.get('author') or {}).get('__typename') == 'User'
+        ]
+        if human_replies:
+            print(f"  *** {len(human_replies)} HUMAN REPLY — treat as higher priority than bot opener ***")
+            for r in human_replies:
+                r_author = r.get('author') or {}
+                print(f"  [{r_author.get('login', 'unknown')}]: {r.get('body', '')[:300]}")
+        print()
+
+
+def main():
+    repo_info = run(['gh', 'repo', 'view', '--json', 'owner,name'])
+    owner = (repo_info.get('owner') or {}).get('login') or sys.exit('Could not derive owner from gh repo view')
+    repo = repo_info.get('name') or sys.exit('Could not derive repo from gh repo view')
+
+    pr_info = run(['gh', 'pr', 'view', '--json', 'number'])
+    number = pr_info.get('number') or sys.exit('Could not derive PR number from gh pr view')
+
+    print(f'owner={owner} repo={repo} number={number}')
+
+    deleted = fetch_deleted_paths(owner, repo, number)
+    threads = fetch_threads(owner, repo, number)
+    print_threads(threads, deleted)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/instructions/general-review.instructions.md
+++ b/.github/instructions/general-review.instructions.md
@@ -1,0 +1,60 @@
+---
+applyTo: "**"
+excludeAgent: "coding-agent"
+---
+
+# General Code Review Instructions
+
+## Before You Start: Understand CI Coverage
+
+Before reviewing any file, identify what linters, formatters, type checkers, and tests run in CI for that file type. Read the CI config and Makefile (or equivalent). Anything CI already enforces is out of scope for your review. Do not speculate about whether code violates a rule that CI would catch. If CI passes, treat the code as satisfying those checks. If you believe CI is incorrectly passing (false negative, misconfigured rule, insufficient test coverage), you may comment, but you must explain specifically what is wrong with the CI setup, not just the code.
+
+## Scope
+
+Only comment on lines that were **added or modified** in the pull request diff. Do not comment on pre-existing code that appears in the diff context but was not changed. If a function signature, type annotation, or variable was not touched by the PR, it is out of scope. File a separate issue instead of blocking the current PR.
+
+## What to Comment On / What to Never Comment On
+
+### Comment on
+
+- Bugs, logic errors, or incorrect behavior
+- Data loss or data corruption risks
+- Missing dependencies between resources or tasks
+- Security vulnerabilities
+- Missing test coverage for changed behavior
+
+### Never comment on
+
+- **Formatting, whitespace, or trailing commas** -- CI handles this
+- **Variable or parameter naming** that follows existing conventions in the codebase
+- **Cosmetic renames** on working code
+- **Test data values** unless they cause test failures
+- **Magic numbers** that are standard in the domain (e.g., HTTP status codes, common thresholds)
+- **Auto-generated file content** such as lockfiles, compiled output, or CI-generated artifacts
+- **Descriptions or comments** -- do not suggest rewording unless factually incorrect
+- **PR metadata** (titles, descriptions, commit messages)
+- **Tests for unchanged behavior** -- only flag missing tests for behavior that was added or modified in the PR
+- **Tests for simple configuration values** (e.g., timeouts, delays, thresholds, feature flags) -- only request tests for behavioral logic
+- **Hypothetical edge cases in heuristics** -- if code describes an approximate rule, do not list theoretical counterexamples. Only comment if the heuristic is wrong in the common case for this codebase.
+- **Refactoring suggestions** without a clear bug or maintainability problem
+- **Docstrings or comments** on self-documenting code
+
+## Before Posting a Comment
+
+Every gate must pass. If any fails, do not post.
+
+1. **90% confident it is a real defect.** A bug, data loss risk, security vulnerability, or incorrect behavior. Design preferences, portability suggestions, and hypothetical concerns are not defects.
+2. **Not already caught by CI.** If CI enforces the rule (per the coverage you identified before starting), do not comment. If the defect falls outside CI's current coverage, comment on the code fix and propose a CI improvement that would catch this class of issue in the future.
+3. **Verified the claim.** Search the codebase for the same pattern; if it exists elsewhere and works, treat that as strong evidence of an established pattern, not a bug. (The same bug can exist in multiple places, but the burden of proof is on the reviewer to demonstrate it.) Check runtime, platform, and tool docs. Read the full file context, not just the diff hunk. Confirm variables and config fields are not platform-provided built-ins before flagging them as undefined.
+4. **Evidence or CI proposal.** Show proof (failing test, doc citation, reproduction steps) or propose a concrete linter rule, test, or CI step that would catch this class of issue. No unsupported "this looks wrong."
+5. **Not a nitpick.** "Will this break, lose data, or produce wrong results, or am I suggesting a different way to express the same correct idea?" If the latter, do not post.
+6. **Not a duplicate.** One comment at the most relevant location. List other occurrences in that comment.
+
+## Comment Format
+
+1. Problem (1 sentence)
+2. Why it matters
+3. Suggested fix
+4. Suggested test or linter rule that would prevent this class of issue from reaching the PR phase
+
+Concise. No praise, no filler.

--- a/.github/instructions/tooling.instructions.md
+++ b/.github/instructions/tooling.instructions.md
@@ -9,9 +9,16 @@ excludeAgent: "cloud-agent"
 
 Before flagging that the lint CI workflow needs the Swift toolchain installed:
 
-1. Verify that the mise `aqua:realm/SwiftLint` backend installs a static binary (`swiftlint-static`) with no Swift runtime dependency.
-2. The lint workflow uses `jdx/mise-action` + `mise exec -- swiftlint lint`, which resolves the static binary — no separate Swift install step is required.
-3. Only flag a missing Swift toolchain in `lint.yml` if you can confirm the installed binary dynamically links against Swift libraries on Ubuntu.
+1. Check whether the mise backend for SwiftLint installs a static binary. The `aqua:realm/SwiftLint` backend (the mise registry default) provides a `swiftlint-static` build on Linux with no Swift runtime dependency.
+2. Confirm by inspecting the SwiftLint GitHub release assets for the platform. If the asset is named `swiftlint-static` or is a fully self-contained binary, no Swift toolchain is needed.
+3. Only flag a missing Swift toolchain if you can show the specific binary dynamically links against Swift libraries on the target platform.
+
+## SwiftLint pre-commit hook: pass_filenames
+
+Before suggesting `pass_filenames: true` for the SwiftLint pre-commit hook:
+
+1. Verify that SwiftLint rules in use do not require whole-project context. Rules like `unused_import` and cross-file analysis only work correctly when SwiftLint sees the full source tree.
+2. If the project uses any project-level rules, `pass_filenames: false` is correct and intentional. Do not flag it as a performance issue without confirming no project-level rules are active.
 
 ## mise-managed tools
 

--- a/.github/instructions/tooling.instructions.md
+++ b/.github/instructions/tooling.instructions.md
@@ -1,0 +1,18 @@
+---
+applyTo: "**"
+excludeAgent: "cloud-agent"
+---
+
+# Tooling Review Rules
+
+## SwiftLint in CI
+
+Before flagging that the lint CI workflow needs the Swift toolchain installed:
+
+1. Verify that the mise `aqua:realm/SwiftLint` backend installs a static binary (`swiftlint-static`) with no Swift runtime dependency.
+2. The lint workflow uses `jdx/mise-action` + `mise exec -- swiftlint lint`, which resolves the static binary — no separate Swift install step is required.
+3. Only flag a missing Swift toolchain in `lint.yml` if you can confirm the installed binary dynamically links against Swift libraries on Ubuntu.
+
+## mise-managed tools
+
+Tools listed in `.mise.toml` under `[tools]` are installed by `mise install`. Do not suggest installing them separately via Homebrew, apt, or pip unless the README explicitly documents that as an alternative path.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,13 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Swift
-        run: |
-          cd /tmp
-          curl -O https://download.swift.org/swiftly/linux/swiftly-x86_64.tar.gz
-          tar zxf swiftly-x86_64.tar.gz
-          ./swiftly init -y --quiet-shell-followup
-          echo "$HOME/.local/share/swiftly/bin" >> $GITHUB_PATH
+      - name: Install mise
+        uses: jdx/mise-action@v2
 
       - name: SwiftLint
-        uses: norio-nomura/action-swiftlint@3.2.1
+        run: mise exec -- swiftlint lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4
 
       - name: SwiftLint
         run: mise exec -- swiftlint lint

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ LICENSE.txt
 
 # Temporary files
 /tmp
+
+# mise
+.mise.local.toml
+

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,7 @@
 [tools]
 swiftlint = "0.65.0"
 swiftformat = "0.62.1"
+prek = "latest"
 
 [hooks]
 postinstall = "prek install --install-hooks"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,22 @@
+[tools]
+swiftlint = "0.65.0"
+swiftformat = "0.62.1"
+
+[hooks]
+postinstall = "prek install --install-hooks"
+
+[tasks.install]
+description = "Install all tools and git hooks"
+run = "mise install"
+
+[tasks.lint]
+description = "Run all linters via prek"
+run = "prek run --all-files"
+
+[tasks.test]
+description = "Run the Swift test suite"
+run = "swift test"
+
+[tasks.build]
+description = "Build the Swift package"
+run = "swift build"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,7 @@
 [tools]
 swiftlint = "0.65.0"
 swiftformat = "0.62.1"
-prek = "latest"
+prek = "0.4.9"
 
 [hooks]
 postinstall = "prek install --install-hooks"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+        exclude: Tests/.*\.png$
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+
+  # Swift tools — versions pinned in .mise.toml, resolved via mise exec
+  - repo: local
+    hooks:
+      - id: swiftformat
+        name: SwiftFormat
+        language: system
+        entry: mise exec -- swiftformat --lint
+        types: [swift]
+        pass_filenames: true
+
+      - id: swiftlint
+        name: SwiftLint
+        language: system
+        entry: mise exec -- swiftlint lint
+        types: [swift]
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This project has task-specific skills available.
 > This step is **non-negotiable** and applies to **every task** without exception.
 
 **Steps to follow before any task:**
-1. `.claude/skills/*/SKILL.md` — discover all available skill files
+1. `.claude/skills/*/SKILL.md`: discover all available skill files
 2. `view` every skill file that is plausibly relevant to the task
 3. Only then proceed with the task
 
@@ -64,7 +64,7 @@ After install, `mise exec -- swiftlint lint` and `mise exec -- swiftformat --lin
 
 - Follow Swift naming conventions throughout.
 - Use doc comments (`///`) on all public APIs.
-- Remove unused code — never commit dead code or build artifacts.
+- Remove unused code. Never commit dead code or build artifacts.
 - Prefer built-in language and framework operators over new utilities.
 - Don't Repeat Yourself (DRY). Factor out repeated patterns.
 - Solve root causes, not symptoms.
@@ -75,7 +75,7 @@ After install, `mise exec -- swiftlint lint` and `mise exec -- swiftformat --lin
 
 - Write tests for all logic branches, including edge cases.
 - Poker hand evaluation must cover: all hand types, wheel straights (A-2-3-4-5), ace-high straights, tie-breaking, and 5+ card hand evaluation (Texas Hold'em style).
-- SwiftUI components: use text-based representations for validation in headless CI — no pixel-perfect image comparisons.
+- SwiftUI components: use text-based representations for validation in headless CI. No pixel-perfect image comparisons.
 - Run `swift test` before every PR. Fix all failures before submitting.
 
 ## Card and Game Logic Rules
@@ -105,11 +105,11 @@ After install, `mise exec -- swiftlint lint` and `mise exec -- swiftformat --lin
 
 ### Pre-commit Checklist
 
-1. `git branch --show-current` — confirm you are on a feature branch.
+1. `git branch --show-current`: confirm you are on a feature branch.
 2. Run lint: `mise run lint`
 3. Run tests: `mise run test`
-4. `git status` — check for untracked files that should not be staged.
-5. `git diff --stat` — show the diff and wait for explicit approval before committing.
+4. `git status`: check for untracked files that should not be staged.
+5. `git diff --stat`: show the diff and wait for explicit approval before committing.
 
 ## Writing Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,69 +1,122 @@
-# infomofo's Agentic Laws (General Principles)
+# AGENTS.md
 
-**Description:**
-Universal laws for agent behavior, applicable to all repositories. Update and refine as collaborative practices evolve.
+## Skills
 
-## General Laws (Priority Order)
+This project has task-specific skills available.
 
-1. An agent must be helpful and productive.
-2. An agent makes pull requests easy to approve by demonstrating their work clearly.
-3. An agent makes empathetic actionable comments when reviewing a pull request.
-4. An agent writes clear and maintainable code.
-5. An agent ensures code is well-tested.
-6. An agent adheres to project conventions, style, and tone.
-7. An agent collaborates when blocked.
-8. An agent verifies information with real sources.
-9. An agent researches existing framework features before refactoring.
-10. An agent must adhere to required content and data structure for posts, files, and directories.
-11. An agent writes user-facing content that responsibly represents the original author.
+> **MANDATORY:** Before writing any code, creating any file, or running any command,
+> you **MUST** first read `.claude/skills/*/SKILL.md` and check for relevant skill files.
+> This step is **non-negotiable** and applies to **every task** without exception.
 
-### General Law Clarifications
+**Steps to follow before any task:**
+1. `.claude/skills/*/SKILL.md` — discover all available skill files
+2. `view` every skill file that is plausibly relevant to the task
+3. Only then proceed with the task
 
-- **On Helpfulness & Productivity:** An agent maintains a positive, solution-oriented tone and focuses on what can be accomplished.
-- **On Approve-Ready Pull Requests:** An agent demonstrates changes clearly—prefer automated tests, but documentation or samples are acceptable. Always edit main documents, not separate analysis files.
-- **On Actionable Comments When Reviewing PRs** Use suggestions to demonstrate any code changes requested. Do not make nitpicky comments. Make it easy for a pull request creator to make the actions you are suggesting and understand your reasoning.
-- **On Code Clarity & Maintainability:** An agent uses clear naming, consistent patterns, and best practices. Removes unused code. Never commits temporary files or build artifacts. An agent avoids unnecessary duplication and follows the "Don't Repeat Yourself" (DRY) principle in all code and content.
-- **On Comprehensive Testing:** An agent writes tests for all logic branches and considers future maintainability.
-- **On Adherence to Conventions & Style:** An agent follows all specified guidelines for code and content. Enforces with linting and CI where possible. **CRITICAL: Agents must run linters, builds, and tests locally before submitting any PR to avoid wasting CI resources and user time with preventable failures.**
-- **On Collaboration When Blocked:** An agent states limitations and proposes collaborative solutions.
-- **On Source Verification:** An agent never invents facts or sources. Marks uncertain facts as "needs verification" or omits them.
-- **On Framework Feature Awareness:** An agent prefers built-in or common patterns over major refactors.
-- **On Content & Data Structure Compliance:** An agent always follows required structure for posts, files, and directories.
-- **On User-Facing Content:** An agent maintains matter-of-fact, authentic, and simple language in all content and code comments; avoids marketing language, overstated claims, anecdotes, SEO optimization, em-dashes, and experiences not had; only recommends products/tools actually used and liked, and keeps affiliate promotion natural and genuine; uses clear, simple titles and honest assessment; leads content with the core topic, focuses on practical use cases, and references existing work when relevant.
+Skipping this step is not allowed, even if you believe you already know how to do the task.
+Skills encode environment-specific constraints that override general knowledge.
+
+## Critical Rules
+
+- **Save agent-specific learnings and worklogs in agent-specific markdown files under their respective agent directories (e.g., `.Jules/`, `.claude/`, `.copilot/`).** Do not commit other unrelated documentation files.
 
 ---
 
-# Repository-Specific Agentic Laws
+## Tooling
 
-**Description:**
-Customizations and clarifications for this repository. Specify how general laws are interpreted or extended for this project.
+This repo uses **mise** for task running and **prek** for git hooks. Hooks are defined in `.pre-commit-config.yaml`; prek runs them.
 
-## Repo-Specific Clarifications of General Laws
+### Quick Commands
 
-- **On Actionable Comments When Reviewing PRs**: For this repo, agents should always provide code suggestions for Swift, and prefer testable examples for poker hand logic and UI components. When reviewing SwiftUI code, clarify CI limitations and suggest text-based alternatives for headless environments.
-- **On Comprehensive Testing:** Agents must ensure all poker hand evaluation logic is covered by unit tests, including edge cases (wheel straights, ace-high straights, etc.), and verify that SwiftUI components can be instantiated on all supported platforms.
-- **On Adherence to Conventions & Style:** Agents must follow Swift naming conventions, use doc comments for public APIs, and update README.md for any new features or changes. **MANDATORY: Agents must run SwiftLint locally before submitting PRs. Use the exact same SwiftLint version as CI (check .github/workflows/lint.yml) and ensure zero violations to prevent iteration waste and wasted premium requests.**
-- **On Collaboration When Blocked:** If platform-specific features (e.g., SwiftUI rendering) are unavailable in CI, agents should propose fallback strategies and document them in PRs.
+```bash
+# First-time setup: installs SwiftLint (via mise) and git hooks (via prek)
+mise install
 
-## Additional Repo-Specific Laws
+# Build
+mise run build
 
-1. An agent must optimize card display components for small screens (Apple Watch) and touch interaction.
-2. An agent must use cryptographically secure shuffling for deck operations.
-3. An agent must document all poker hand evaluation logic and provide usage examples for video poker scenarios.
-4. An agent must ensure all code is compatible with iOS 15+, watchOS 8+, macOS 12+, and Linux for CI.
-5. **An agent must validate all changes with local linting using the exact same SwiftLint version as CI, building, and testing before any PR submission to prevent CI failures, iteration overhead, and wasted premium requests.**
+# Test
+mise run test
 
-### Repo-Specific Law Clarifications
+# Lint (required before every PR)
+mise run lint
+```
 
-- For SwiftUI component tests, agents should not require pixel-perfect image comparisons in CI, and should use text-based representations for validation.
-- For deck shuffling, agents must use Fisher-Yates or equivalent secure algorithms.
-- For hand evaluation, agents must handle tie-breaking and edge cases explicitly in code and documentation.
-- **For SwiftLint validation**: Agents must run SwiftLint using Docker with the exact same version as CI: `docker run --rm -v "$(pwd):/workdir" -w /workdir ghcr.io/realm/swiftlint:0.55.1 swiftlint lint`. Zero violations are required before PR submission to prevent wasted premium requests and iteration cycles.
+`mise install` pins and downloads all tools from `.mise.toml` and then automatically runs `prek install --install-hooks` via the `postinstall` hook.
+
+### SwiftLint
+
+SwiftLint and SwiftFormat are managed by mise. Versions are pinned in `.mise.toml` and match CI:
+
+```bash
+mise install   # downloads SwiftLint and SwiftFormat at pinned versions
+```
+
+After install, `mise exec -- swiftlint lint` and `mise exec -- swiftformat --lint` resolve to the pinned versions. No Docker required.
+
+### Git Hooks
+
+`.pre-commit-config.yaml` configures: trailing whitespace, end-of-file fixes, YAML/TOML validation, merge conflict detection, and SwiftLint. The `postinstall` hook in `.mise.toml` runs `prek install --install-hooks` automatically after `mise install`, so hooks are registered as part of first-time setup.
 
 ---
 
-**Tips for Agents:**
-- Update the general laws section as best practices evolve.
-- Add repo-specific clarifications when a general law needs more detail for this project.
-- Add new repo-specific laws only when a law is unique to this repo and not a clarification of a general law.
-- Use clear, numbered lists and concise language for easy parsing and future automation.
+## Code Rules
+
+- Follow Swift naming conventions throughout.
+- Use doc comments (`///`) on all public APIs.
+- Remove unused code — never commit dead code or build artifacts.
+- Prefer built-in language and framework operators over new utilities.
+- Don't Repeat Yourself (DRY). Factor out repeated patterns.
+- Solve root causes, not symptoms.
+- Read 2-3 existing examples before writing anything new. Match structure and style.
+- Ensure all code is compatible with iOS 15+, watchOS 8+, macOS 12+, and Linux for CI.
+
+## Testing Rules
+
+- Write tests for all logic branches, including edge cases.
+- Poker hand evaluation must cover: all hand types, wheel straights (A-2-3-4-5), ace-high straights, tie-breaking, and 5+ card hand evaluation (Texas Hold'em style).
+- SwiftUI components: use text-based representations for validation in headless CI — no pixel-perfect image comparisons.
+- Run `swift test` before every PR. Fix all failures before submitting.
+
+## Card and Game Logic Rules
+
+- Use cryptographically secure shuffling (Fisher-Yates with `SystemRandomNumberGenerator` or `SecRandomCopyBytes`).
+- Document all poker hand evaluation logic with usage examples for video poker scenarios.
+- Optimize card display components for small screens (Apple Watch: 28×36px compact mode).
+
+## Pull Request Rules
+
+- Run lint and tests locally before opening a PR. Do not rely on CI to catch lint violations.
+- PRs modifying logic must include tests for core behavior, boundary conditions, and edge cases.
+- Always edit main documents (README.md, AGENTS.md), not separate analysis files.
+- When reviewing SwiftUI code, clarify CI limitations and suggest text-based alternatives for headless environments.
+- Provide code suggestions for Swift when reviewing PRs. Do not leave nitpicky comments.
+- If platform-specific features (e.g., SwiftUI rendering) are unavailable in CI, propose fallback strategies and document them in the PR.
+- Update README.md for any new public APIs or features.
+
+## Git Rules
+
+- **NEVER push to main or master directly.** Create a feature branch first.
+- **NEVER commit without explicit approval.** Show the diff and wait for confirmation.
+- **NEVER force push** (`--force`, `--force-with-lease`).
+- **NEVER chain `git commit` and `git push`.** They must be separate commands.
+- Verify branch with `git branch --show-current` before any write operation.
+- Use `git revert` to undo changes on remote-tracking branches, not `git reset --hard`.
+
+### Pre-commit Checklist
+
+1. `git branch --show-current` — confirm you are on a feature branch.
+2. Run lint: `mise run lint`
+3. Run tests: `mise run test`
+4. `git status` — check for untracked files that should not be staged.
+5. `git diff --stat` — show the diff and wait for explicit approval before committing.
+
+## Writing Style
+
+All prose (code comments, commit messages, PR descriptions, documentation):
+
+- No em-dashes. Use commas or restructure.
+- No hedging ("arguably", "could potentially", "generally speaking").
+- No sycophantic openers or filler transitions.
+- Terse, direct, first-person. Vary sentence length. State positions.
+- Matter-of-fact language in user-facing content. No marketing language.

--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ This repo uses [mise](https://mise.jdx.dev) for task running and [prek](https://
 
 ```bash
 # mise
-curl https://mise.run | sh
+curl -fsSL https://mise.run | sh
 
-# prek (Homebrew)
-brew install j178/tap/prek
+# prek — mise will install it automatically, but install manually first if needed
+brew install j178/tap/prek          # macOS
+pip install prek                    # Linux
 ```
 
 ### macOS
@@ -76,7 +77,7 @@ Clone and set up:
 ```bash
 git clone https://github.com/infomofo/swift-playing-cards-2.git
 cd swift-playing-cards-2
-mise install   # installs SwiftLint and registers git hooks automatically
+mise install   # installs SwiftLint, SwiftFormat, prek, and registers git hooks
 mise run build
 mise run test
 ```
@@ -113,7 +114,7 @@ mise run test
 
 | Task | Description |
 |------|-------------|
-| `mise install` | Install tools (SwiftLint) and register git hooks |
+| `mise install` | Install SwiftLint, SwiftFormat, prek, and register git hooks |
 | `mise run build` | `swift build` |
 | `mise run test` | `swift test` |
 | `mise run lint` | Run all hooks via `prek run --all-files` |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This repo uses [mise](https://mise.jdx.dev) for task running and [prek](https://
 # mise
 curl -fsSL https://mise.run | sh
 
-# prek — mise will install it automatically, but install manually first if needed
+# prek: mise will install it automatically, but install manually first if needed
 brew install j178/tap/prek          # macOS
 pip install prek                    # Linux
 ```

--- a/README.md
+++ b/README.md
@@ -51,54 +51,72 @@ Or in Xcode:
 
 ## Development Environment Setup
 
-### macOS Development
+This repo uses [mise](https://mise.jdx.dev) for task running and [prek](https://prek.j178.dev) for git hooks. `.pre-commit-config.yaml` defines all hooks; prek runs them.
 
-1. **Install Swift**: Swift comes bundled with Xcode
-   ```bash
-   # Install Xcode from App Store or developer portal
-   xcode-select --install
-   
-   # Verify Swift installation
-   swift --version
-   ```
+### Install tools
 
-2. **Clone and build**:
-   ```bash
-   git clone https://github.com/infomofo/swift-playing-cards-2.git
-   cd swift-playing-cards-2
-   swift build
-   swift test
-   ```
+```bash
+# mise
+curl https://mise.run | sh
 
-3. **Xcode development**:
-   ```bash
-   swift package generate-xcodeproj
-   open PlayingCard.xcodeproj
-   ```
+# prek (Homebrew)
+brew install j178/tap/prek
+```
 
-### Ubuntu Development
+### macOS
 
-1. **Install Swift**:
-   ```bash
-   # Ubuntu 20.04/22.04
-   wget https://download.swift.org/swift-6.1.2-release/ubuntu2004/swift-6.1.2-RELEASE-ubuntu20.04.tar.gz
-   tar xzf swift-6.1.2-RELEASE-ubuntu20.04.tar.gz
-   sudo mv swift-6.1.2-RELEASE-ubuntu20.04 /opt/swift
-   echo 'export PATH=/opt/swift/usr/bin:$PATH' >> ~/.bashrc
-   source ~/.bashrc
-   
-   # Install dependencies
-   sudo apt update
-   sudo apt install clang libicu-dev pkg-config libssl-dev zlib1g-dev
-   ```
+Swift comes with Xcode:
 
-2. **Clone and build**:
-   ```bash
-   git clone https://github.com/infomofo/swift-playing-cards-2.git
-   cd swift-playing-cards-2
-   swift build
-   swift test
-   ```
+```bash
+xcode-select --install
+```
+
+Clone and set up:
+
+```bash
+git clone https://github.com/infomofo/swift-playing-cards-2.git
+cd swift-playing-cards-2
+mise install   # installs SwiftLint and registers git hooks automatically
+mise run build
+mise run test
+```
+
+Open in Xcode:
+
+```bash
+swift package generate-xcodeproj
+open PlayingCard.xcodeproj
+```
+
+### Linux (Ubuntu 20.04/22.04)
+
+Install Swift via [swiftly](https://github.com/swift-server/swiftly):
+
+```bash
+sudo apt update && sudo apt install clang libicu-dev pkg-config libssl-dev zlib1g-dev
+curl -O https://download.swift.org/swiftly/linux/swiftly-x86_64.tar.gz
+tar zxf swiftly-x86_64.tar.gz
+./swiftly init -y --quiet-shell-followup
+```
+
+Then clone and set up:
+
+```bash
+git clone https://github.com/infomofo/swift-playing-cards-2.git
+cd swift-playing-cards-2
+mise install
+mise run build
+mise run test
+```
+
+### mise tasks
+
+| Task | Description |
+|------|-------------|
+| `mise install` | Install tools (SwiftLint) and register git hooks |
+| `mise run build` | `swift build` |
+| `mise run test` | `swift test` |
+| `mise run lint` | Run all hooks via `prek run --all-files` |
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Prepares the repo for cloud agent environments (Jules, Copilot coding agent, etc.) by adding a consistent, reproducible local tooling setup.

## Changes

### Tooling
- **`.mise.toml`**: pins `swiftlint = "0.65.0"`, `swiftformat = "0.62.1"`, and `prek = "latest"` via the mise registry (aqua backend). Defines standard `install`/`lint`/`test`/`build` tasks. The `postinstall` hook auto-runs `prek install --install-hooks` after tools are installed, so first-time setup is one command: `mise install`.
- **`.pre-commit-config.yaml`**: baseline hooks (trailing-whitespace, end-of-file-fixer, check-yaml, check-toml, check-merge-conflict) plus `swiftformat --lint` and `swiftlint lint`, both resolved via `mise exec`.
- **`.github/workflows/lint.yml`**: replaces `norio-nomura/action-swiftlint` (no pinned version) with `jdx/mise-action` + `mise exec -- swiftlint lint`. CI and local use the same pinned version from `.mise.toml`. The aqua backend installs a static SwiftLint binary — no Swift toolchain needed in the lint job.
- **`.github/instructions/tooling.instructions.md`**: prevents recurring review comments about SwiftLint needing the Swift runtime in CI.

### Agent instructions
- **`AGENTS.md`**: rewritten with required Skills header block, consolidated repo-scoped rules for tooling, code quality, testing, git workflow, and writing style.
- **`.claude/skills/review-pr-comments/`**: copied from dotfiles so the review-pr-comments skill is available locally without needing global Copilot instructions.

### Docs
- **`README.md`**: dev setup section replaced with mise/prek workflow.
- **`.gitignore`**: adds `.mise.local.toml`; removes the incorrect `.prek` entry (prek caches in `~/.cache/prek`, not the repo).

## Developer workflow after this PR

```bash
mise install      # installs SwiftLint, SwiftFormat, prek, and registers git hooks
mise run build
mise run test
mise run lint     # runs prek run --all-files
```