### PR TITLE
Add expectedValue(for:holding:) for single-hold EV lookup

### DIFF
--- a/Sources/PlayingCard/OptimalPlay.swift
+++ b/Sources/PlayingCard/OptimalPlay.swift
@@ -158,9 +158,14 @@ public struct OptimalPlay {
     /// - Returns: Expected payout multiplier averaged over all possible draw completions.
     public func expectedValue(for hand: [PlayingCard], holding: Set<Int>) -> Double {
         precondition(hand.count == 5, "OptimalPlay requires exactly 5 dealt cards")
+        precondition(
+            holding.allSatisfy { (0 ..< 5).contains($0) },
+            "holding indices must be in 0..<5"
+        )
         let suitOrder: [Suit: Int] = [.spades: 0, .hearts: 1, .diamonds: 2, .clubs: 3]
         let handCodes = hand.map { (($0.rank.rawValue - 2) << 2) | suitOrder[$0.suit]! }
         let handSet = Set(handCodes)
+        precondition(handSet.count == 5, "hand must contain 5 unique cards")
         var remaining: [Int] = []
         remaining.reserveCapacity(47)
         for suitIdx in 0 ..< 4 {

--- a/Sources/PlayingCard/OptimalPlay.swift
+++ b/Sources/PlayingCard/OptimalPlay.swift
@@ -146,6 +146,35 @@ public struct OptimalPlay {
         )
     }
 
+    /// Returns the expected payout multiplier for one specific hold set, without
+    /// evaluating all 32 combinations.
+    ///
+    /// Use this when the optimal hold is already known (e.g. precomputed during the
+    /// deal phase) and you only need the player's EV for a specific set of held indices.
+    ///
+    /// - Parameters:
+    ///   - hand: Exactly 5 dealt cards.
+    ///   - holding: Indices (0–4) to hold; empty set means draw all 5.
+    /// - Returns: Expected payout multiplier averaged over all possible draw completions.
+    public func expectedValue(for hand: [PlayingCard], holding: Set<Int>) -> Double {
+        precondition(hand.count == 5, "OptimalPlay requires exactly 5 dealt cards")
+        let suitOrder: [Suit: Int] = [.spades: 0, .hearts: 1, .diamonds: 2, .clubs: 3]
+        let handCodes = hand.map { (($0.rank.rawValue - 2) << 2) | suitOrder[$0.suit]! }
+        let handSet = Set(handCodes)
+        var remaining: [Int] = []
+        remaining.reserveCapacity(47)
+        for suitIdx in 0 ..< 4 {
+            for rankIdx in 0 ..< 13 {
+                let code = (rankIdx << 2) | suitIdx
+                if !handSet.contains(code) {
+                    remaining.append(code)
+                }
+            }
+        }
+        let heldCodes = holding.sorted().map { handCodes[$0] }
+        return fastEV(held: heldCodes, remaining: remaining)
+    }
+
     // MARK: - Fast Inner Loop
 
     /// Computes expected payout by iterating all C(remaining.count, drawCount) completions.

--- a/Tests/PlayingCardTests/OptimalPlayTests.swift
+++ b/Tests/PlayingCardTests/OptimalPlayTests.swift
@@ -297,4 +297,52 @@ final class OptimalPlayTests: XCTestCase {
         XCTAssertEqual(result.optimalHeld, [0, 1, 2, 3, 4])
         XCTAssertEqual(result.optimalEV, 0.0, accuracy: 0.001)
     }
+
+    // MARK: - expectedValue(for:holding:)
+
+    /// `expectedValue` must match `evaluate`'s `playerEV` for a pat royal flush (hold all 5).
+    func testExpectedValueMatchesEvaluatePatRoyal() throws {
+        let hand = [
+            PlayingCard(rank: .ace, suit: .spades),
+            PlayingCard(rank: .king, suit: .spades),
+            PlayingCard(rank: .queen, suit: .spades),
+            PlayingCard(rank: .jack, suit: .spades),
+            PlayingCard(rank: .ten, suit: .spades),
+        ]
+        let holding = Set([0, 1, 2, 3, 4])
+        let ev = engine.expectedValue(for: hand, holding: holding)
+        let playerEV = try XCTUnwrap(engine.evaluate(hand: hand, playerHeld: holding).playerEV)
+        XCTAssertEqual(ev, playerEV, accuracy: 0.001)
+        XCTAssertEqual(ev, 800.0, accuracy: 0.001)
+    }
+
+    /// `expectedValue` must match `evaluate`'s `playerEV` for a 4-to-royal hold.
+    func testExpectedValueMatchesEvaluateFourToRoyal() throws {
+        let hand = [
+            PlayingCard(rank: .ace, suit: .spades),
+            PlayingCard(rank: .king, suit: .spades),
+            PlayingCard(rank: .queen, suit: .spades),
+            PlayingCard(rank: .jack, suit: .spades),
+            PlayingCard(rank: .ten, suit: .hearts),
+        ]
+        let holding = Set([0, 1, 2, 3])
+        let ev = engine.expectedValue(for: hand, holding: holding)
+        let playerEV = try XCTUnwrap(engine.evaluate(hand: hand, playerHeld: holding).playerEV)
+        XCTAssertEqual(ev, playerEV, accuracy: 0.001)
+    }
+
+    /// `expectedValue` must match `evaluate`'s `playerEV` when holding nothing (draw 5).
+    func testExpectedValueMatchesEvaluateHoldingNothing() throws {
+        let hand = [
+            PlayingCard(rank: .two, suit: .spades),
+            PlayingCard(rank: .four, suit: .hearts),
+            PlayingCard(rank: .six, suit: .clubs),
+            PlayingCard(rank: .eight, suit: .diamonds),
+            PlayingCard(rank: .ten, suit: .hearts),
+        ]
+        let holding = Set<Int>([])
+        let ev = engine.expectedValue(for: hand, holding: holding)
+        let playerEV = try XCTUnwrap(engine.evaluate(hand: hand, playerHeld: holding).playerEV)
+        XCTAssertEqual(ev, playerEV, accuracy: 0.001)
+    }
 }


### PR DESCRIPTION
Adds a fast path for computing EV for one specific hold set, without running all 32 combinations.

**Why**: Enables a two-phase pattern in the app:
1. During the deal phase (player is deciding), run `evaluate()` — all 32 combos — in the background. This precomputes the optimal hold.
2. After draw, call `expectedValue(for:holding:)` with the player's actual hold — one combination pass, essentially instant on any hardware.

Result: the strategy badge appears immediately after the draw resolves instead of ~1s later.

**Implementation**: same integer encoding + `fastEV` path as `evaluate()`, just called once for the specified hold set.