### PR TITLE
Step 3: StrategyPattern enum and HoldClassifier

### DIFF
--- a/Sources/PlayingCard/StrategyPattern.swift
+++ b/Sources/PlayingCard/StrategyPattern.swift
@@ -164,14 +164,14 @@ public struct HoldClassifier {
             if rankCounts.values.contains(3) {
                 return .threeOfAKind
             }
-            if let pairRank = rankCounts.first(where: { $0.value == 2 })?.key {
-                return pairRank >= 11 ? .highPair : .lowPair
+            let pairRanks = rankCounts.filter { $0.value == 2 }.map { $0.key }
+            if !pairRanks.isEmpty {
+                return pairRanks.max()! >= 11 ? .highPair : .lowPair
             }
             return .lowPair
         }
 
-        // Open-ended: 4 consecutive ranks (span == 3), excludable from royal
-        // (A-2-3-4 wheel and A-K-Q-J broadway both count as outside).
+        // Open-ended: 4 consecutive ranks completable on both ends (span == 3, ace not high).
         if isOutsideStraightDraw(sorted) {
             return .fourToOutsideStraight
         }
@@ -293,28 +293,34 @@ public struct HoldClassifier {
         return false
     }
 
-    /// Open-ended straight draw: 4 unique consecutive ranks (span == 3).
+    /// Open-ended straight draw: 4 unique consecutive ranks completable on both ends.
     ///
-    /// Also handles A-2-3-4 (wheel open-ender) and J-Q-K-A (broadway open-ender).
+    /// Excludes ace-high sequences (J-Q-K-A) and ace-low wheel sequences (A-2-3-4)
+    /// because both are one-ended and are classified as inside draws instead.
     private static func isOutsideStraightDraw(_ sorted: [Int]) -> Bool {
         guard sorted.count == 4, Set(sorted).count == 4 else { return false }
-        // Standard consecutive
-        if sorted[3] - sorted[0] == 3 {
-            return true
-        }
-        // A-2-3-4: ace(14) + 2+3+4 = [2,3,4,14] after sorting
-        if sorted == [2, 3, 4, 14] {
+        // Standard consecutive, excluding ace-high (J-Q-K-A can only complete with 10).
+        if sorted[3] - sorted[0] == 3 && sorted[3] != 14 {
             return true
         }
         return false
     }
 
-    /// Inside (gutshot) straight draw: 4 unique ranks spanning 4 with exactly one gap.
+    /// Inside (gutshot) straight draw: 4 unique ranks spanning 4 with exactly one gap,
+    /// plus one-ended boundary draws (A-2-3-4 and J-Q-K-A).
     private static func isInsideStraightDraw(_ sorted: [Int]) -> Bool {
         guard sorted.count == 4, Set(sorted).count == 4 else { return false }
+        // A-2-3-4: wheel one-ender (only 5 completes).
+        if sorted == [2, 3, 4, 14] {
+            return true
+        }
+        // J-Q-K-A: broadway one-ender (only 10 completes).
+        if sorted == [11, 12, 13, 14] {
+            return true
+        }
         let span = sorted[3] - sorted[0]
         guard span == 4 else { return false }
-        // Exactly 3 consecutive pairs means one gap exists
+        // Exactly 2 consecutive pairs means one gap exists.
         var consecutivePairs = 0
         for idx in 0 ..< 3 where sorted[idx + 1] - sorted[idx] == 1 {
             consecutivePairs += 1

--- a/Sources/PlayingCard/StrategyPattern.swift
+++ b/Sources/PlayingCard/StrategyPattern.swift
@@ -168,7 +168,7 @@ public struct HoldClassifier {
             if !pairRanks.isEmpty {
                 return pairRanks.max()! >= 11 ? .highPair : .lowPair
             }
-            return .lowPair
+            preconditionFailure("4-card hold has duplicates but no pair, trips, or quads: impossible rank distribution")
         }
 
         // Open-ended: 4 consecutive ranks completable on both ends (span == 3, ace not high).
@@ -179,7 +179,7 @@ public struct HoldClassifier {
         if isInsideStraightDraw(sorted) {
             return .fourToInsideStraight
         }
-        // Two high cards with two non-matching lower cards: treat as high pair fallback
+        // Mixed suits with no straight draw: classify by high card count.
         let highCount = ranks.filter { $0 >= 11 }.count
         if highCount >= 2 {
             return .twoUnsuitedHighCards

--- a/Sources/PlayingCard/StrategyPattern.swift
+++ b/Sources/PlayingCard/StrategyPattern.swift
@@ -31,10 +31,10 @@ public enum StrategyPattern: String, Equatable, CaseIterable, Sendable {
     case highPair = "High pair"
     /// Three suited cards all within {T, J, Q, K, A}.
     case threeToRoyalFlush = "Three to a royal flush"
-    /// Four suited cards that are not all royal-eligible.
-    case fourToFlush = "Four to a flush"
     /// Four suited cards that can complete to a straight flush.
     case fourToStraightFlush = "Four to a straight flush"
+    /// Four suited cards that are not all royal-eligible.
+    case fourToFlush = "Four to a flush"
     /// A pair of twos through tens.
     case lowPair = "Low pair"
     /// Four consecutive cards that can be completed on either end.
@@ -154,11 +154,19 @@ public struct HoldClassifier {
             return .fourToFlush
         }
 
-        // Mixed suits — look for straight draws.
+        // Mixed suits: look for straight draws.
         let sorted = ranks.sorted()
         guard Set(ranks).count == 4 else {
-            // Duplicate ranks: this is a pat three/four of a kind dealt situation,
-            // but with 4 held and duplicates, check for pair content.
+            let rankCounts = Dictionary(grouping: ranks, by: { $0 }).mapValues { $0.count }
+            if rankCounts.values.contains(4) {
+                return .fourOfAKind
+            }
+            if rankCounts.values.contains(3) {
+                return .threeOfAKind
+            }
+            if let pairRank = rankCounts.first(where: { $0.value == 2 })?.key {
+                return pairRank >= 11 ? .highPair : .lowPair
+            }
             return .lowPair
         }
 
@@ -171,12 +179,15 @@ public struct HoldClassifier {
         if isInsideStraightDraw(sorted) {
             return .fourToInsideStraight
         }
-        // Two high cards with two non-matching lower cards — treat as high pair fallback
+        // Two high cards with two non-matching lower cards: treat as high pair fallback
         let highCount = ranks.filter { $0 >= 11 }.count
         if highCount >= 2 {
             return .twoUnsuitedHighCards
         }
-        return .oneHighCard
+        if highCount == 1 {
+            return .oneHighCard
+        }
+        return .discardAll
     }
 
     // MARK: - Three cards
@@ -201,9 +212,7 @@ public struct HoldClassifier {
             if canFormStraightFlush(ranks) {
                 return .threeToStraightFlush
             }
-            // Three suited cards outside straight-flush range — still a SF draw candidate
-            // if they span <= 4 with a gap. Use flush-draw label.
-            return .threeToStraightFlush
+            // Falls through to high-card logic below.
         }
 
         // Mixed suits: check for pairs (two cards of same rank with a third).
@@ -212,7 +221,7 @@ public struct HoldClassifier {
             return pairRank >= 11 ? .highPair : .lowPair
         }
 
-        // Three different ranks, mixed suits — look for high cards.
+        // Three different ranks, mixed suits: look for high cards.
         let highRanks = ranks.filter { $0 >= 11 }
         switch highRanks.count {
         case 2: return .twoUnsuitedHighCards
@@ -278,7 +287,7 @@ public struct HoldClassifier {
         // Wheel: ace (14) + two/three/four/five
         let hasAce = sorted.contains(14)
         let lowRanks = sorted.filter { $0 != 14 }
-        if hasAce && lowRanks.allSatisfy({ $0 <= 5 }) && (lowRanks.last! - lowRanks.first!) <= (ranks.count - 2) {
+        if hasAce && lowRanks.allSatisfy({ $0 <= 5 }) {
             return true
         }
         return false

--- a/Sources/PlayingCard/StrategyPattern.swift
+++ b/Sources/PlayingCard/StrategyPattern.swift
@@ -1,0 +1,315 @@
+/// Names the strategic intent of a hold combination in Jacks or Better video poker.
+///
+/// Cases are listed in descending priority order matching the standard Jacks or Better
+/// strategy hierarchy. When the classifier detects multiple matching patterns, it returns
+/// the highest-priority one.
+public enum StrategyPattern: String, Equatable, CaseIterable, Sendable {
+    // MARK: - Pat hands (all 5 cards held)
+
+    /// Suited A-K-Q-J-T.
+    case royalFlush = "Royal flush"
+    /// Suited straight (not royal).
+    case straightFlush = "Straight flush"
+    /// Four cards of the same rank.
+    case fourOfAKind = "Four of a kind"
+    /// Three of a kind plus a pair.
+    case fullHouse = "Full house"
+    /// Five cards of the same suit (not straight).
+    case flush = "Flush"
+    /// Five consecutive ranks (not suited).
+    case straight = "Straight"
+    /// Three cards of the same rank (held as 3 or held pat).
+    case threeOfAKind = "Three of a kind"
+    /// Two separate pairs (all 5 held).
+    case twoPair = "Two pair"
+
+    // MARK: - Partial holds
+
+    /// Four suited cards all within {T, J, Q, K, A}.
+    case fourToRoyalFlush = "Four to a royal flush"
+    /// A pair of jacks, queens, kings, or aces.
+    case highPair = "High pair"
+    /// Three suited cards all within {T, J, Q, K, A}.
+    case threeToRoyalFlush = "Three to a royal flush"
+    /// Four suited cards that are not all royal-eligible.
+    case fourToFlush = "Four to a flush"
+    /// Four suited cards that can complete to a straight flush.
+    case fourToStraightFlush = "Four to a straight flush"
+    /// A pair of twos through tens.
+    case lowPair = "Low pair"
+    /// Four consecutive cards that can be completed on either end.
+    case fourToOutsideStraight = "Four to an outside straight"
+    /// Four cards to a straight with one internal gap.
+    case fourToInsideStraight = "Four to an inside straight"
+    /// Three suited cards that can complete to a straight flush.
+    case threeToStraightFlush = "Three to a straight flush"
+    /// Two suited cards both ranking jack or higher.
+    case twoSuitedHighCards = "Two suited high cards"
+    /// Two unsuited cards both ranking jack or higher.
+    case twoUnsuitedHighCards = "Two unsuited high cards"
+    /// A ten and a high card (J–A) of the same suit.
+    case suitedTenHighCard = "Suited 10 with high card"
+    /// A single jack, queen, king, or ace.
+    case oneHighCard = "One high card"
+    /// No cards held.
+    case discardAll = "Discard all"
+}
+
+// MARK: - HoldClassifier
+
+/// Classifies a hold combination by its Jacks or Better strategy pattern.
+///
+/// ## Usage
+///
+/// ```swift
+/// let pattern = HoldClassifier.classify(hand: dealtCards, holding: [0, 2, 4])
+/// print(pattern.rawValue) // e.g. "Three to a royal flush"
+/// ```
+public struct HoldClassifier {
+    private init() {}
+
+    /// Returns the highest-priority strategy pattern for the given hold set.
+    ///
+    /// When the held cards match multiple patterns (e.g. four suited high cards
+    /// is both four-to-royal and four-to-flush), the higher-priority pattern wins.
+    ///
+    /// - Parameters:
+    ///   - hand: Exactly 5 dealt cards.
+    ///   - holding: Indices (0–4) the player chose to hold.
+    public static func classify(hand: [PlayingCard], holding: Set<Int>) -> StrategyPattern {
+        precondition(hand.count == 5, "HoldClassifier requires exactly 5 dealt cards")
+        precondition(
+            holding.allSatisfy { (0 ..< 5).contains($0) },
+            "holding indices must be in 0...4"
+        )
+
+        let held = holding.sorted().map { hand[$0] }
+
+        switch held.count {
+        case 0:
+            return .discardAll
+        case 1:
+            return classifyOne(held[0])
+        case 2:
+            return classifyTwo(held[0], held[1])
+        case 3:
+            return classifyThree(held)
+        case 4:
+            return classifyFour(held)
+        case 5:
+            return classifyFive(held)
+        default:
+            preconditionFailure("holding set cannot have more than 5 elements")
+        }
+    }
+
+    // MARK: - Five cards
+
+    private static func classifyFive(_ cards: [PlayingCard]) -> StrategyPattern {
+        switch Hand(cards: cards).evaluate() {
+        case .royalFlush:
+            return .royalFlush
+        case .straightFlush:
+            return .straightFlush
+        case .fourOfAKind:
+            return .fourOfAKind
+        case .fullHouse:
+            return .fullHouse
+        case .flush:
+            return .flush
+        case .straight:
+            return .straight
+        case .threeOfAKind:
+            return .threeOfAKind
+        case .twoPair:
+            return .twoPair
+        case .pair:
+            let pairRank = cards.first(where: { card in cards.filter { $0.rank == card.rank }.count == 2 })!.rank
+            return pairRank.rawValue >= 11 ? .highPair : .lowPair
+        case .highCard:
+            // Unusual to hold all 5 with no pair; return best single-card pattern.
+            if let highCard = cards.max(by: { $0.rank < $1.rank }), highCard.rank.rawValue >= 11 {
+                return .oneHighCard
+            }
+            return .discardAll
+        }
+    }
+
+    // MARK: - Four cards
+
+    private static func classifyFour(_ cards: [PlayingCard]) -> StrategyPattern {
+        let suits = cards.map(\.suit)
+        let ranks = cards.map { $0.rank.rawValue }
+        let allSameSuit = Set(suits).count == 1
+
+        if allSameSuit {
+            // All 4 in royal set {T, J, Q, K, A} (rawValues 10–14)?
+            if ranks.allSatisfy({ $0 >= 10 }) {
+                return .fourToRoyalFlush
+            }
+            // Can form a straight flush: all unique ranks, span <= 4 (or wheel)?
+            if canFormStraightFlush(ranks) {
+                return .fourToStraightFlush
+            }
+            return .fourToFlush
+        }
+
+        // Mixed suits — look for straight draws.
+        let sorted = ranks.sorted()
+        guard Set(ranks).count == 4 else {
+            // Duplicate ranks: this is a pat three/four of a kind dealt situation,
+            // but with 4 held and duplicates, check for pair content.
+            return .lowPair
+        }
+
+        // Open-ended: 4 consecutive ranks (span == 3), excludable from royal
+        // (A-2-3-4 wheel and A-K-Q-J broadway both count as outside).
+        if isOutsideStraightDraw(sorted) {
+            return .fourToOutsideStraight
+        }
+        // Inside: span == 4 with exactly one internal gap.
+        if isInsideStraightDraw(sorted) {
+            return .fourToInsideStraight
+        }
+        // Two high cards with two non-matching lower cards — treat as high pair fallback
+        let highCount = ranks.filter { $0 >= 11 }.count
+        if highCount >= 2 {
+            return .twoUnsuitedHighCards
+        }
+        return .oneHighCard
+    }
+
+    // MARK: - Three cards
+
+    private static func classifyThree(_ cards: [PlayingCard]) -> StrategyPattern {
+        let ranks = cards.map { $0.rank.rawValue }
+        let suits = cards.map(\.suit)
+
+        // Three of a kind?
+        if Set(ranks).count == 1 {
+            return .threeOfAKind
+        }
+
+        let allSameSuit = Set(suits).count == 1
+
+        if allSameSuit {
+            // All in royal set {T, J, Q, K, A}?
+            if ranks.allSatisfy({ $0 >= 10 }) {
+                return .threeToRoyalFlush
+            }
+            // Straight flush draw: span <= 4 (or wheel)?
+            if canFormStraightFlush(ranks) {
+                return .threeToStraightFlush
+            }
+            // Three suited cards outside straight-flush range — still a SF draw candidate
+            // if they span <= 4 with a gap. Use flush-draw label.
+            return .threeToStraightFlush
+        }
+
+        // Mixed suits: check for pairs (two cards of same rank with a third).
+        let rankCounts = Dictionary(grouping: ranks, by: { $0 }).mapValues { $0.count }
+        if let pairRank = rankCounts.first(where: { $0.value == 2 })?.key {
+            return pairRank >= 11 ? .highPair : .lowPair
+        }
+
+        // Three different ranks, mixed suits — look for high cards.
+        let highRanks = ranks.filter { $0 >= 11 }
+        switch highRanks.count {
+        case 2: return .twoUnsuitedHighCards
+        case 1: return .oneHighCard
+        default: return .discardAll
+        }
+    }
+
+    // MARK: - Two cards
+
+    private static func classifyTwo(_ first: PlayingCard, _ second: PlayingCard) -> StrategyPattern {
+        // Pair?
+        if first.rank == second.rank {
+            return first.rank.rawValue >= 11 ? .highPair : .lowPair
+        }
+
+        let firstVal = first.rank.rawValue
+        let secondVal = second.rank.rawValue
+        let firstHigh = firstVal >= 11
+        let secondHigh = secondVal >= 11
+        let firstTen = first.rank == .ten
+        let secondTen = second.rank == .ten
+        let sameSuit = first.suit == second.suit
+
+        if sameSuit {
+            if firstHigh && secondHigh {
+                return .twoSuitedHighCards
+            }
+            if (firstTen && secondHigh) || (firstHigh && secondTen) {
+                return .suitedTenHighCard
+            }
+        } else {
+            if firstHigh && secondHigh {
+                return .twoUnsuitedHighCards
+            }
+        }
+
+        if firstHigh || secondHigh {
+            return .oneHighCard
+        }
+
+        return .discardAll
+    }
+
+    // MARK: - One card
+
+    private static func classifyOne(_ card: PlayingCard) -> StrategyPattern {
+        return card.rank.rawValue >= 11 ? .oneHighCard : .discardAll
+    }
+
+    // MARK: - Helpers
+
+    /// Returns true when 3 or 4 ranks (as rawValues) can form a straight flush.
+    ///
+    /// Criteria: all unique, span (max - min) <= 4, OR ace-low wheel.
+    private static func canFormStraightFlush(_ ranks: [Int]) -> Bool {
+        let sorted = ranks.sorted()
+        guard Set(ranks).count == ranks.count else { return false }
+        let span = sorted.last! - sorted.first!
+        if span <= 4 {
+            return true
+        }
+        // Wheel: ace (14) + two/three/four/five
+        let hasAce = sorted.contains(14)
+        let lowRanks = sorted.filter { $0 != 14 }
+        if hasAce && lowRanks.allSatisfy({ $0 <= 5 }) && (lowRanks.last! - lowRanks.first!) <= (ranks.count - 2) {
+            return true
+        }
+        return false
+    }
+
+    /// Open-ended straight draw: 4 unique consecutive ranks (span == 3).
+    ///
+    /// Also handles A-2-3-4 (wheel open-ender) and J-Q-K-A (broadway open-ender).
+    private static func isOutsideStraightDraw(_ sorted: [Int]) -> Bool {
+        guard sorted.count == 4, Set(sorted).count == 4 else { return false }
+        // Standard consecutive
+        if sorted[3] - sorted[0] == 3 {
+            return true
+        }
+        // A-2-3-4: ace(14) + 2+3+4 = [2,3,4,14] after sorting
+        if sorted == [2, 3, 4, 14] {
+            return true
+        }
+        return false
+    }
+
+    /// Inside (gutshot) straight draw: 4 unique ranks spanning 4 with exactly one gap.
+    private static func isInsideStraightDraw(_ sorted: [Int]) -> Bool {
+        guard sorted.count == 4, Set(sorted).count == 4 else { return false }
+        let span = sorted[3] - sorted[0]
+        guard span == 4 else { return false }
+        // Exactly 3 consecutive pairs means one gap exists
+        var consecutivePairs = 0
+        for idx in 0 ..< 3 where sorted[idx + 1] - sorted[idx] == 1 {
+            consecutivePairs += 1
+        }
+        return consecutivePairs == 2
+    }
+}

--- a/Tests/PlayingCardTests/HoldClassifierTests.swift
+++ b/Tests/PlayingCardTests/HoldClassifierTests.swift
@@ -259,20 +259,22 @@ struct HoldClassifierTests {
         #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToOutsideStraight)
     }
 
-    @Test func fourToOutsideStraightBroadway() {
+    @Test func fourToInsideStraightBroadway() {
+        // J-Q-K-A: only a 10 completes, so one-ended (inside).
         let hand = [
             card(.jack, .spades), card(.queen, .hearts), card(.king, .diamonds),
             card(.ace, .clubs), card(.two, .spades),
         ]
-        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToOutsideStraight)
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToInsideStraight)
     }
 
-    @Test func fourToOutsideStraightWheel() {
+    @Test func fourToInsideStraightWheel() {
+        // A-2-3-4: only a 5 completes (ace-low wheel), so one-ended (inside).
         let hand = [
             card(.ace, .spades), card(.two, .hearts), card(.three, .diamonds),
             card(.four, .clubs), card(.king, .spades),
         ]
-        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToOutsideStraight)
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToInsideStraight)
     }
 
     // MARK: - Four to Inside Straight
@@ -524,6 +526,24 @@ struct HoldClassifierPriorityTests {
             card(.king, .diamonds), card(.two, .spades),
         ]
         #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .threeOfAKind)
+    }
+
+    /// Two-pair 4-card hold: J-J-3-3 must deterministically return .highPair.
+    @Test func fourCardHoldTwoPairHighWins() {
+        let hand = [
+            card(.jack, .spades), card(.jack, .hearts), card(.three, .clubs),
+            card(.three, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .highPair)
+    }
+
+    /// Two-pair 4-card hold with both low pairs returns .lowPair.
+    @Test func fourCardHoldTwoPairBothLow() {
+        let hand = [
+            card(.five, .spades), card(.five, .hearts), card(.three, .clubs),
+            card(.three, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .lowPair)
     }
 
     // MARK: - classifyFour zero-high-cards fix (Thread 4)

--- a/Tests/PlayingCardTests/HoldClassifierTests.swift
+++ b/Tests/PlayingCardTests/HoldClassifierTests.swift
@@ -1,0 +1,464 @@
+import PlayingCard
+import Testing
+
+// MARK: - Shared helpers
+
+extension HoldClassifierTests {
+    func card(_ rank: Rank, _ suit: Suit) -> PlayingCard {
+        PlayingCard(rank: rank, suit: suit)
+    }
+
+    func classify(hand: [PlayingCard], holding: Set<Int>) -> StrategyPattern {
+        HoldClassifier.classify(hand: hand, holding: holding)
+    }
+}
+
+@Suite("HoldClassifier — basic patterns")
+struct HoldClassifierTests {
+    // MARK: - Discard All / One Card
+
+    @Test func testDiscardAll() {
+        let hand = [
+            card(.two, .hearts), card(.five, .clubs), card(.seven, .diamonds),
+            card(.nine, .spades), card(.jack, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: []) == .discardAll)
+    }
+
+    @Test func oneHighCardJack() {
+        let hand = [
+            card(.jack, .spades), card(.three, .hearts), card(.six, .clubs),
+            card(.eight, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0]) == .oneHighCard)
+    }
+
+    @Test func oneHighCardAce() {
+        let hand = [
+            card(.ace, .hearts), card(.four, .clubs), card(.seven, .spades),
+            card(.nine, .diamonds), card(.two, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [0]) == .oneHighCard)
+    }
+
+    @Test func oneLowCardIsDiscardAll() {
+        let hand = [
+            card(.two, .hearts), card(.five, .clubs), card(.seven, .diamonds),
+            card(.nine, .spades), card(.jack, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [0]) == .discardAll)
+    }
+
+    // MARK: - High Pair
+
+    @Test func highPairJacks() {
+        let hand = [
+            card(.jack, .spades), card(.jack, .hearts), card(.three, .clubs),
+            card(.seven, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1]) == .highPair)
+    }
+
+    @Test func highPairAces() {
+        let hand = [
+            card(.ace, .spades), card(.ace, .hearts), card(.three, .clubs),
+            card(.seven, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1]) == .highPair)
+    }
+
+    // MARK: - Low Pair
+
+    @Test func lowPairTens() {
+        let hand = [
+            card(.ten, .spades), card(.ten, .hearts), card(.three, .clubs),
+            card(.seven, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1]) == .lowPair)
+    }
+
+    @Test func lowPairTwos() {
+        let hand = [
+            card(.two, .spades), card(.two, .hearts), card(.three, .clubs),
+            card(.seven, .diamonds), card(.jack, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1]) == .lowPair)
+    }
+
+    // MARK: - Two Suited High Cards
+
+    @Test func twoSuitedHighCardsAceKing() {
+        let hand = [
+            card(.ace, .spades), card(.king, .spades), card(.three, .clubs),
+            card(.seven, .diamonds), card(.two, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1]) == .twoSuitedHighCards)
+    }
+
+    @Test func twoSuitedHighCardsQueenJack() {
+        let hand = [
+            card(.queen, .hearts), card(.jack, .hearts), card(.three, .clubs),
+            card(.seven, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1]) == .twoSuitedHighCards)
+    }
+
+    // MARK: - Two Unsuited High Cards
+
+    @Test func twoUnsuitedHighCardsKingQueen() {
+        let hand = [
+            card(.king, .spades), card(.queen, .hearts), card(.three, .clubs),
+            card(.seven, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1]) == .twoUnsuitedHighCards)
+    }
+
+    @Test func twoUnsuitedHighCardsAceJack() {
+        let hand = [
+            card(.ace, .clubs), card(.jack, .diamonds), card(.three, .hearts),
+            card(.seven, .spades), card(.two, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1]) == .twoUnsuitedHighCards)
+    }
+
+    // MARK: - Suited Ten + High Card
+
+    @Test func suitedTenKing() {
+        let hand = [
+            card(.ten, .spades), card(.king, .spades), card(.three, .clubs),
+            card(.seven, .diamonds), card(.two, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1]) == .suitedTenHighCard)
+    }
+
+    @Test func suitedTenAce() {
+        let hand = [
+            card(.ten, .hearts), card(.ace, .hearts), card(.three, .clubs),
+            card(.seven, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1]) == .suitedTenHighCard)
+    }
+
+    // MARK: - Three to Royal Flush
+
+    @Test func threeToRoyalFlushUserExample() {
+        // K♠ T♠ Q♠ — optimal in the user's K♠ T♠ 3♣ Q♠ 8♠ hand
+        let hand = [
+            card(.king, .spades), card(.ten, .spades), card(.three, .clubs),
+            card(.queen, .spades), card(.eight, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 3]) == .threeToRoyalFlush)
+    }
+
+    @Test func threeToRoyalFlushAceKingJack() {
+        let hand = [
+            card(.ace, .diamonds), card(.king, .diamonds), card(.jack, .diamonds),
+            card(.three, .clubs), card(.seven, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToRoyalFlush)
+    }
+
+    @Test func threeToRoyalFlushQueenJackTen() {
+        let hand = [
+            card(.queen, .clubs), card(.jack, .clubs), card(.ten, .clubs),
+            card(.two, .hearts), card(.nine, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToRoyalFlush)
+    }
+
+    // MARK: - Three to Straight Flush
+
+    @Test func threeToStraightFlushConsecutive() {
+        let hand = [
+            card(.seven, .hearts), card(.eight, .hearts), card(.nine, .hearts),
+            card(.ace, .spades), card(.king, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlush)
+    }
+
+    @Test func threeToStraightFlushWithGap() {
+        let hand = [
+            card(.six, .clubs), card(.eight, .clubs), card(.nine, .clubs),
+            card(.ace, .spades), card(.king, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlush)
+    }
+
+    // MARK: - Three of a Kind (3-card hold)
+
+    @Test func threeOfAKindHeld() {
+        let hand = [
+            card(.seven, .spades), card(.seven, .hearts), card(.seven, .diamonds),
+            card(.ace, .clubs), card(.king, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeOfAKind)
+    }
+
+    // MARK: - Four to Royal Flush
+
+    @Test func fourToRoyalFlushThroughKing() {
+        let hand = [
+            card(.ten, .spades), card(.jack, .spades), card(.queen, .spades),
+            card(.king, .spades), card(.two, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToRoyalFlush)
+    }
+
+    @Test func fourToRoyalFlushAceHigh() {
+        let hand = [
+            card(.ace, .hearts), card(.king, .hearts), card(.queen, .hearts),
+            card(.jack, .hearts), card(.three, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToRoyalFlush)
+    }
+
+    // MARK: - Four to Straight Flush
+
+    @Test func fourToStraightFlushConsecutive() {
+        let hand = [
+            card(.five, .clubs), card(.six, .clubs), card(.seven, .clubs),
+            card(.eight, .clubs), card(.ace, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToStraightFlush)
+    }
+
+    @Test func fourToStraightFlushNotFlush() {
+        let hand = [
+            card(.three, .hearts), card(.four, .hearts), card(.five, .hearts),
+            card(.six, .hearts), card(.ace, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToStraightFlush)
+    }
+
+    // MARK: - Four to Flush
+
+    @Test func fourToFlushNonConsecutive() {
+        let hand = [
+            card(.two, .spades), card(.five, .spades), card(.nine, .spades),
+            card(.king, .spades), card(.ace, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToFlush)
+    }
+
+    @Test func fourToFlushUserExample() {
+        // K♠ T♠ Q♠ 8♠ — player's suboptimal hold (8 breaks royal set)
+        let hand = [
+            card(.king, .spades), card(.ten, .spades), card(.three, .clubs),
+            card(.queen, .spades), card(.eight, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 3, 4]) == .fourToFlush)
+    }
+
+    // MARK: - Four to Outside Straight
+
+    @Test func fourToOutsideStraightConsecutive() {
+        let hand = [
+            card(.five, .spades), card(.six, .hearts), card(.seven, .diamonds),
+            card(.eight, .clubs), card(.ace, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToOutsideStraight)
+    }
+
+    @Test func fourToOutsideStraightBroadway() {
+        let hand = [
+            card(.jack, .spades), card(.queen, .hearts), card(.king, .diamonds),
+            card(.ace, .clubs), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToOutsideStraight)
+    }
+
+    @Test func fourToOutsideStraightWheel() {
+        let hand = [
+            card(.ace, .spades), card(.two, .hearts), card(.three, .diamonds),
+            card(.four, .clubs), card(.king, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToOutsideStraight)
+    }
+
+    // MARK: - Four to Inside Straight
+
+    @Test func testFourToInsideStraight() {
+        let hand = [
+            card(.five, .spades), card(.six, .hearts), card(.eight, .diamonds),
+            card(.nine, .clubs), card(.ace, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToInsideStraight)
+    }
+
+    @Test func fourToInsideStraightHighCards() {
+        let hand = [
+            card(.ten, .spades), card(.jack, .hearts), card(.queen, .diamonds),
+            card(.ace, .clubs), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToInsideStraight)
+    }
+
+    // MARK: - Pat hands (five cards held)
+
+    @Test func patRoyalFlush() {
+        let hand = [
+            card(.ace, .spades), card(.king, .spades), card(.queen, .spades),
+            card(.jack, .spades), card(.ten, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3, 4]) == .royalFlush)
+    }
+
+    @Test func patStraightFlush() {
+        let hand = [
+            card(.nine, .hearts), card(.eight, .hearts), card(.seven, .hearts),
+            card(.six, .hearts), card(.five, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3, 4]) == .straightFlush)
+    }
+
+    @Test func patFourOfAKind() {
+        let hand = [
+            card(.king, .spades), card(.king, .hearts), card(.king, .diamonds),
+            card(.king, .clubs), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3, 4]) == .fourOfAKind)
+    }
+
+    @Test func patFullHouse() {
+        let hand = [
+            card(.ace, .spades), card(.ace, .hearts), card(.ace, .diamonds),
+            card(.king, .clubs), card(.king, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3, 4]) == .fullHouse)
+    }
+
+    @Test func patFlush() {
+        let hand = [
+            card(.ace, .clubs), card(.nine, .clubs), card(.seven, .clubs),
+            card(.five, .clubs), card(.two, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3, 4]) == .flush)
+    }
+
+    @Test func patStraight() {
+        let hand = [
+            card(.nine, .spades), card(.eight, .hearts), card(.seven, .clubs),
+            card(.six, .diamonds), card(.five, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3, 4]) == .straight)
+    }
+
+    @Test func patThreeOfAKind() {
+        let hand = [
+            card(.eight, .spades), card(.eight, .hearts), card(.eight, .clubs),
+            card(.king, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3, 4]) == .threeOfAKind)
+    }
+
+    @Test func patTwoPair() {
+        let hand = [
+            card(.ace, .spades), card(.ace, .hearts), card(.king, .clubs),
+            card(.king, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3, 4]) == .twoPair)
+    }
+
+    @Test func patHighPair() {
+        let hand = [
+            card(.king, .spades), card(.king, .hearts), card(.three, .clubs),
+            card(.seven, .diamonds), card(.two, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3, 4]) == .highPair)
+    }
+
+    @Test func patLowPair() {
+        let hand = [
+            card(.nine, .spades), card(.nine, .hearts), card(.three, .clubs),
+            card(.seven, .diamonds), card(.two, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3, 4]) == .lowPair)
+    }
+}
+
+@Suite("HoldClassifier — priority edge cases")
+struct HoldClassifierPriorityTests {
+    private func card(_ rank: Rank, _ suit: Suit) -> PlayingCard {
+        PlayingCard(rank: rank, suit: suit)
+    }
+
+    private func classify(hand: [PlayingCard], holding: Set<Int>) -> StrategyPattern {
+        HoldClassifier.classify(hand: hand, holding: holding)
+    }
+
+    /// Four suited high cards → four to royal (not four-to-flush or four-to-SF)
+    @Test func fourHighSuitedBeatsFlush() {
+        let hand = [
+            card(.ace, .clubs), card(.king, .clubs), card(.queen, .clubs),
+            card(.ten, .clubs), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToRoyalFlush)
+    }
+
+    /// Four suited consecutive non-high → four to SF (not four to flush)
+    @Test func fourConsecutiveSuitedBeatsBareFlush() {
+        let hand = [
+            card(.four, .diamonds), card(.five, .diamonds), card(.six, .diamonds),
+            card(.seven, .diamonds), card(.ace, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToStraightFlush)
+    }
+
+    /// Three suited high cards → three to royal (not three to SF)
+    @Test func threeHighSuitedBeatsThreeToSF() {
+        let hand = [
+            card(.ace, .hearts), card(.queen, .hearts), card(.ten, .hearts),
+            card(.three, .clubs), card(.seven, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToRoyalFlush)
+    }
+
+    /// Two suited high cards preferred over unsuited when same suit
+    @Test func suitedHighCardsBeatUnsuited() {
+        let suited = [
+            card(.ace, .spades), card(.king, .spades), card(.three, .clubs),
+            card(.seven, .diamonds), card(.two, .hearts),
+        ]
+        #expect(classify(hand: suited, holding: [0, 1]) == .twoSuitedHighCards)
+        let unsuited = [
+            card(.ace, .spades), card(.king, .hearts), card(.three, .clubs),
+            card(.seven, .diamonds), card(.two, .clubs),
+        ]
+        #expect(classify(hand: unsuited, holding: [0, 1]) == .twoUnsuitedHighCards)
+    }
+
+    /// Suited T + high card: ten is not high (< J) but pattern takes priority
+    @Test func suitedTenHighCardOverUnsuitedHigh() {
+        let hand = [
+            card(.ten, .clubs), card(.king, .clubs), card(.three, .spades),
+            card(.seven, .hearts), card(.two, .diamonds),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1]) == .suitedTenHighCard)
+    }
+
+    /// Three-card hold with embedded pair: pair pattern wins
+    @Test func threeCardHoldPairWins() {
+        let hand = [
+            card(.jack, .spades), card(.jack, .hearts), card(.three, .clubs),
+            card(.seven, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .highPair)
+    }
+
+    @Test func threeCardHoldLowPairWins() {
+        let hand = [
+            card(.five, .spades), card(.five, .hearts), card(.king, .clubs),
+            card(.seven, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .lowPair)
+    }
+
+    /// Four-to-royal beats four-to-straight-flush when all high suited
+    @Test func fourToRoyalBeats4ToSF() {
+        let hand = [
+            card(.ten, .diamonds), card(.jack, .diamonds), card(.queen, .diamonds),
+            card(.king, .diamonds), card(.nine, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToRoyalFlush)
+    }
+}

--- a/Tests/PlayingCardTests/HoldClassifierTests.swift
+++ b/Tests/PlayingCardTests/HoldClassifierTests.swift
@@ -13,7 +13,7 @@ extension HoldClassifierTests {
     }
 }
 
-@Suite("HoldClassifier — basic patterns")
+@Suite("HoldClassifier: basic patterns")
 struct HoldClassifierTests {
     // MARK: - Discard All / One Card
 
@@ -142,7 +142,7 @@ struct HoldClassifierTests {
     // MARK: - Three to Royal Flush
 
     @Test func threeToRoyalFlushUserExample() {
-        // K♠ T♠ Q♠ — optimal in the user's K♠ T♠ 3♣ Q♠ 8♠ hand
+        // K♠ T♠ Q♠: optimal in the user's K♠ T♠ 3♣ Q♠ 8♠ hand
         let hand = [
             card(.king, .spades), card(.ten, .spades), card(.three, .clubs),
             card(.queen, .spades), card(.eight, .spades),
@@ -241,7 +241,7 @@ struct HoldClassifierTests {
     }
 
     @Test func fourToFlushUserExample() {
-        // K♠ T♠ Q♠ 8♠ — player's suboptimal hold (8 breaks royal set)
+        // K♠ T♠ Q♠ 8♠: player's suboptimal hold (8 breaks royal set)
         let hand = [
             card(.king, .spades), card(.ten, .spades), card(.three, .clubs),
             card(.queen, .spades), card(.eight, .spades),
@@ -376,7 +376,7 @@ struct HoldClassifierTests {
     }
 }
 
-@Suite("HoldClassifier — priority edge cases")
+@Suite("HoldClassifier: priority edge cases")
 struct HoldClassifierPriorityTests {
     private func card(_ rank: Rank, _ suit: Suit) -> PlayingCard {
         PlayingCard(rank: rank, suit: suit)
@@ -460,5 +460,91 @@ struct HoldClassifierPriorityTests {
             card(.king, .diamonds), card(.nine, .hearts),
         ]
         #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToRoyalFlush)
+    }
+
+    // MARK: - classifyThree suited fallback fix (Thread 1)
+
+    /// Three suited cards that span > 4 and aren't royal-eligible should fall
+    /// through to high-card logic, not be mislabeled as a straight-flush draw.
+    @Test func threeSuitedNonSFDrawFallsToHighCard() {
+        // 2♣ 9♣ K♣: span 11, not a SF draw; K is a high card
+        let hand = [
+            card(.two, .clubs), card(.nine, .clubs), card(.king, .clubs),
+            card(.three, .hearts), card(.seven, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .oneHighCard)
+    }
+
+    @Test func threeSuitedNonSFDrawNoHighCard() {
+        // 2♣ 5♣ 9♣: span 7, not a SF draw, no high cards
+        let hand = [
+            card(.two, .clubs), card(.five, .clubs), card(.nine, .clubs),
+            card(.king, .hearts), card(.seven, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .discardAll)
+    }
+
+    // MARK: - canFormStraightFlush wheel fix (Thread 2)
+
+    /// A-2-4-5 suited is a valid wheel SF draw (can complete to A-2-3-4-5).
+    @Test func fourToStraightFlushWheelWithGap() {
+        let hand = [
+            card(.ace, .hearts), card(.two, .hearts), card(.four, .hearts),
+            card(.five, .hearts), card(.king, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToStraightFlush)
+    }
+
+    /// A-2-5 suited (3 cards) is a valid wheel SF draw.
+    @Test func threeToStraightFlushWheelWithGap() {
+        let hand = [
+            card(.ace, .spades), card(.two, .spades), card(.five, .spades),
+            card(.king, .hearts), card(.nine, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlush)
+    }
+
+    // MARK: - classifyFour duplicate-ranks fix (Thread 3)
+
+    /// Holding 4 cards that include a high pair must return .highPair, not .lowPair.
+    @Test func fourCardHoldHighPair() {
+        // J♠ J♥ 3♣ 7♦ held as 4 cards
+        let hand = [
+            card(.jack, .spades), card(.jack, .hearts), card(.three, .clubs),
+            card(.seven, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .highPair)
+    }
+
+    /// Holding 4 cards with trips must return .threeOfAKind, not .lowPair.
+    @Test func fourCardHoldTrips() {
+        // 7♠ 7♥ 7♣ K♦ held as 4 cards
+        let hand = [
+            card(.seven, .spades), card(.seven, .hearts), card(.seven, .clubs),
+            card(.king, .diamonds), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .threeOfAKind)
+    }
+
+    // MARK: - classifyFour zero-high-cards fix (Thread 4)
+
+    /// Four mixed-suit low cards with no straight draw should be .discardAll.
+    @Test func fourMixedLowNoDrawIsDiscardAll() {
+        // 2♠ 4♥ 8♦ 9♣: span 7, no straight draw, no high cards
+        let hand = [
+            card(.two, .spades), card(.four, .hearts), card(.eight, .diamonds),
+            card(.nine, .clubs), card(.king, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .discardAll)
+    }
+
+    /// Four mixed-suit cards with exactly one high card returns .oneHighCard.
+    @Test func fourMixedOneHighCardReturnsOneHighCard() {
+        // 5♠ 6♥ 9♦ K♣: no straight draw, one high card
+        let hand = [
+            card(.five, .spades), card(.six, .hearts), card(.nine, .diamonds),
+            card(.king, .clubs), card(.two, .spades),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .oneHighCard)
     }
 }


### PR DESCRIPTION
## Summary

Adds the strategy pattern labeling infrastructure needed for coaching and the upcoming step 4 animation.

## New Public API

### `StrategyPattern` (enum, 22 cases)

Names the strategic intent of any hold combination in Jacks or Better, in descending priority order:
`royalFlush`, `straightFlush`, `fourOfAKind`, `fullHouse`, `flush`, `straight`, `threeOfAKind`, `twoPair`, `fourToRoyalFlush`, `highPair`, `threeToRoyalFlush`, `fourToStraightFlush`, `fourToFlush`, `lowPair`, `fourToOutsideStraight`, `fourToInsideStraight`, `threeToStraightFlush`, `twoSuitedHighCards`, `twoUnsuitedHighCards`, `suitedTenHighCard`, `oneHighCard`, `discardAll`

### `HoldClassifier`

```swift
let pattern = HoldClassifier.classify(hand: dealtCards, holding: [0, 1, 3])
// "Three to a royal flush"
```

Priority rules implemented (highest wins when multiple match):
- 4 suited: royal > straight flush > flush
- 4 mixed: outside straight > inside straight
- 3 suited: royal > straight flush; embedded pairs win
- 2 cards: high pair > low pair > suited high > suited T+high > unsuited high

## User's Example Resolved

Hand: K♠ T♠ 3♣ Q♠ 8♠

- Player held K♠ T♠ Q♠ 8♠ → **"Four to a flush"**
- Optimal held K♠ T♠ Q♠ → **"Three to a royal flush"**

Coaching text can now say: *"Your play (four to a flush): EV 1.27 vs Optimal (three to a royal flush): EV 1.42"*

## Tests (57)

All 22 pattern cases covered. Priority edge cases explicitly verified.