### PR TITLE
Fix classifyThree: add threeToFlush for suited non-SF/non-royal holds

### DIFF
--- a/Sources/PlayingCard/StrategyPattern.swift
+++ b/Sources/PlayingCard/StrategyPattern.swift
@@ -35,16 +35,36 @@ public enum StrategyPattern: String, Equatable, CaseIterable, Sendable {
     case fourToStraightFlush = "Four to a straight flush"
     /// Four suited cards that are not all royal-eligible.
     case fourToFlush = "Four to a flush"
+    /// Mixed-suit T-J-Q-K: the only 4-card outside straight with 3 high cards.
+    ///
+    /// EV 0.87 — ranks above a low pair (EV 0.82). WoO optimal entry #14.
+    case unsuitedTJQK = "Unsuited T-J-Q-K"
     /// A pair of twos through tens.
     case lowPair = "Low pair"
-    /// Four consecutive cards that can be completed on either end.
+    /// Four consecutive cards that can be completed on either end (0–2 high cards).
+    ///
+    /// EV ~0.68 — ranks below a low pair. For T-J-Q-K specifically, see ``unsuitedTJQK``.
     case fourToOutsideStraight = "Four to an outside straight"
     /// Four cards to a straight with one internal gap.
     case fourToInsideStraight = "Four to an inside straight"
-    /// Three suited cards that can complete to a straight flush.
-    case threeToStraightFlush = "Three to a straight flush"
+    /// Three suited cards forming a straight flush draw, type 1: high cards (J+) ≥ gaps.
+    ///
+    /// Examples: 9-T-J suited (0 gaps, 1 high), 8-J-Q suited (2 gaps, 2 high). EV ~0.63.
+    /// Ranks above suited QJ on the WoO optimal list.
+    case threeToStraightFlushType1 = "Three to a straight flush (type 1)"
+    /// Three suited cards forming a straight flush draw, type 2.
+    ///
+    /// Covers: 1 gap + 0 high cards; 2 gaps + 1 high card; ace-low suited; 2-3-4 suited.
+    /// Examples: 6-8-9 suited, A-2-4 suited, 2-3-4 suited. EV ~0.52.
+    case threeToStraightFlushType2 = "Three to a straight flush (type 2)"
+    /// Three suited cards forming a straight flush draw, type 3: 2 gaps, no high cards.
+    ///
+    /// Examples: 3-5-7 suited, 4-6-8 suited. EV 0.44 — weaker than holding a single high card.
+    case threeToStraightFlushType3 = "Three to a straight flush (type 3)"
     /// Three suited cards not forming a royal or straight flush draw.
     case threeToFlush = "Three to a flush"
+    /// Three mixed-suit cards all within {T, J, Q, K, A}, no pair.
+    case threeUnsuitedHighCards = "Three unsuited high cards"
     /// Two suited cards both ranking jack or higher.
     case twoSuitedHighCards = "Two suited high cards"
     /// Two unsuited cards both ranking jack or higher.
@@ -175,6 +195,11 @@ public struct HoldClassifier {
 
         // Open-ended: 4 consecutive ranks completable on both ends (span == 3, ace not high).
         if isOutsideStraightDraw(sorted) {
+            // TJQK is the only outside straight with 3 high cards (EV 0.87, above low pair).
+            // All other outside straights have 0–2 high cards (EV ~0.68, below low pair).
+            if sorted == [10, 11, 12, 13] {
+                return .unsuitedTJQK
+            }
             return .fourToOutsideStraight
         }
         // Inside: span == 4 with exactly one internal gap.
@@ -210,9 +235,9 @@ public struct HoldClassifier {
             if ranks.allSatisfy({ $0 >= 10 }) {
                 return .threeToRoyalFlush
             }
-            // Straight flush draw: span <= 4 (or wheel)?
+            // Straight flush draw: classify into WoO type (determines EV tier).
             if canFormStraightFlush(ranks) {
-                return .threeToStraightFlush
+                return classifyThreeToSFType(ranks: ranks)
             }
             // Three suited cards that don't qualify as royal or SF draw.
             return .threeToFlush
@@ -226,6 +251,10 @@ public struct HoldClassifier {
 
         // Three different ranks, mixed suits: look for high cards.
         let highRanks = ranks.filter { $0 >= 11 }
+        // All three in royal set {T, J, Q, K, A}: three unsuited high cards.
+        if ranks.allSatisfy({ $0 >= 10 }) {
+            return .threeUnsuitedHighCards
+        }
         switch highRanks.count {
         case 2: return .twoUnsuitedHighCards
         case 1: return .oneHighCard
@@ -276,6 +305,43 @@ public struct HoldClassifier {
     }
 
     // MARK: - Helpers
+
+    /// Classifies a 3-card suited straight flush draw into WoO types 1, 2, or 3.
+    ///
+    /// Called only when `canFormStraightFlush` already returned true.
+    ///
+    /// - Type 1: high cards (J+) ≥ gaps. EV ~0.63. Ranks above suited QJ.
+    /// - Type 2: 1 gap + 0 high; 2 gaps + 1 high; ace-low; 2-3-4. EV ~0.52.
+    /// - Type 3: 2 gaps + 0 high cards. EV 0.44 — weaker than holding a lone high card.
+    private static func classifyThreeToSFType(ranks: [Int]) -> StrategyPattern {
+        let sorted = ranks.sorted()
+        let highCards = sorted.filter { $0 >= 11 }.count
+
+        // Ace-low: ace + two low cards (all ≤ 5) — wheel-direction draw, always type 2.
+        if sorted.contains(14) {
+            let nonAce = sorted.filter { $0 != 14 }
+            if nonAce.allSatisfy({ $0 <= 5 }) {
+                return .threeToStraightFlushType2
+            }
+        }
+
+        // 2-3-4: explicitly type 2 per WoO (limited completion paths, similar to ace-low).
+        if sorted == [2, 3, 4] {
+            return .threeToStraightFlushType2
+        }
+
+        // Number of interior gaps: for 3 cards, gapCount = span - 2.
+        let span = sorted.last! - sorted.first!
+        let gapCount = span - 2
+
+        if highCards >= gapCount {
+            return .threeToStraightFlushType1
+        }
+        if gapCount == 2 && highCards == 0 {
+            return .threeToStraightFlushType3
+        }
+        return .threeToStraightFlushType2
+    }
 
     /// Returns true when 3 or 4 ranks (as rawValues) can form a straight flush.
     ///

--- a/Sources/PlayingCard/StrategyPattern.swift
+++ b/Sources/PlayingCard/StrategyPattern.swift
@@ -43,6 +43,8 @@ public enum StrategyPattern: String, Equatable, CaseIterable, Sendable {
     case fourToInsideStraight = "Four to an inside straight"
     /// Three suited cards that can complete to a straight flush.
     case threeToStraightFlush = "Three to a straight flush"
+    /// Three suited cards not forming a royal or straight flush draw.
+    case threeToFlush = "Three to a flush"
     /// Two suited cards both ranking jack or higher.
     case twoSuitedHighCards = "Two suited high cards"
     /// Two unsuited cards both ranking jack or higher.
@@ -212,7 +214,8 @@ public struct HoldClassifier {
             if canFormStraightFlush(ranks) {
                 return .threeToStraightFlush
             }
-            // Falls through to high-card logic below.
+            // Three suited cards that don't qualify as royal or SF draw.
+            return .threeToFlush
         }
 
         // Mixed suits: check for pairs (two cards of same rank with a third).

--- a/Tests/PlayingCardTests/HoldClassifierTests.swift
+++ b/Tests/PlayingCardTests/HoldClassifierTests.swift
@@ -168,20 +168,31 @@ struct HoldClassifierTests {
 
     // MARK: - Three to Straight Flush
 
+    /// Consecutive suited cards — type 1 (0 gaps). EV ~0.63.
     @Test func threeToStraightFlushConsecutive() {
         let hand = [
             card(.seven, .hearts), card(.eight, .hearts), card(.nine, .hearts),
             card(.ace, .spades), card(.king, .clubs),
         ]
-        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlush)
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlushType1)
     }
 
+    /// Suited cards with one gap, no high cards — type 2. EV ~0.52.
     @Test func threeToStraightFlushWithGap() {
         let hand = [
             card(.six, .clubs), card(.eight, .clubs), card(.nine, .clubs),
             card(.ace, .spades), card(.king, .hearts),
         ]
-        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlush)
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlushType2)
+    }
+
+    /// Two gaps, no high cards — type 3 (EV 0.44, weaker than one high card).
+    @Test func threeToStraightFlushType3() {
+        let hand = [
+            card(.three, .clubs), card(.five, .clubs), card(.seven, .clubs),
+            card(.king, .hearts), card(.two, .diamonds),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlushType3)
     }
 
     // MARK: - Three to Flush (regression cases)
@@ -217,6 +228,28 @@ struct HoldClassifierTests {
             card(.six, .clubs), card(.two, .diamonds),
         ]
         #expect(classify(hand: hand, holding: [1, 2, 3]) == .threeToFlush)
+    }
+
+    // MARK: - Three Unsuited High Cards
+
+    /// Three mixed-suit royal-eligible cards (T, J, K) → threeUnsuitedHighCards.
+    /// Regression: previously returned twoUnsuitedHighCards, causing circular coaching
+    /// ("better than two unsuited high cards" when optimal was also twoUnsuitedHighCards).
+    /// Hand: 7d Jd Ts 5s Kh, held Jd Ts Kh (indices 1,2,4).
+    @Test func threeUnsuitedHighCardsTJK() {
+        let hand = [
+            card(.seven, .diamonds), card(.jack, .diamonds), card(.ten, .spades),
+            card(.five, .spades), card(.king, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [1, 2, 4]) == .threeUnsuitedHighCards)
+    }
+
+    @Test func threeUnsuitedHighCardsJQK() {
+        let hand = [
+            card(.two, .clubs), card(.jack, .spades), card(.queen, .hearts),
+            card(.king, .diamonds), card(.three, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [1, 2, 3]) == .threeUnsuitedHighCards)
     }
 
     // MARK: - Three of a Kind (3-card hold)
@@ -532,13 +565,13 @@ struct HoldClassifierPriorityTests {
         #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToStraightFlush)
     }
 
-    /// A-2-5 suited (3 cards) is a valid wheel SF draw.
+    /// A-2-5 suited: ace-low wheel draw, always type 2 per WoO.
     @Test func threeToStraightFlushWheelWithGap() {
         let hand = [
             card(.ace, .spades), card(.two, .spades), card(.five, .spades),
             card(.king, .hearts), card(.nine, .clubs),
         ]
-        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlush)
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlushType2)
     }
 
     // MARK: - classifyFour duplicate-ranks fix (Thread 3)
@@ -601,5 +634,76 @@ struct HoldClassifierPriorityTests {
             card(.king, .clubs), card(.two, .spades),
         ]
         #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .oneHighCard)
+    }
+
+    // MARK: - SF type 1 variants
+
+    /// 9-T-J suited: span 2, 0 gaps, 1 high card (J). 1 ≥ 0 → type 1.
+    @Test func threeToStraightFlushType1NineTenJack() {
+        let hand = [
+            card(.nine, .clubs), card(.ten, .clubs), card(.jack, .clubs),
+            card(.two, .hearts), card(.five, .diamonds),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlushType1)
+    }
+
+    /// 8-J-Q suited: span 4, 2 gaps, 2 high cards (J, Q). 2 ≥ 2 → type 1.
+    @Test func threeToStraightFlushType1EightJackQueen() {
+        let hand = [
+            card(.eight, .diamonds), card(.jack, .diamonds), card(.queen, .diamonds),
+            card(.three, .clubs), card(.six, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlushType1)
+    }
+
+    // MARK: - SF type 2 variants
+
+    /// A-2-4 suited: ace-low, nonAce=[2,4] all ≤5 → type 2.
+    @Test func threeToStraightFlushType2AceLow() {
+        let hand = [
+            card(.ace, .spades), card(.two, .spades), card(.four, .spades),
+            card(.king, .hearts), card(.seven, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlushType2)
+    }
+
+    /// 2-3-4 suited: explicitly type 2 per WoO (limited completion paths).
+    @Test func threeToStraightFlushType2TwoThreeFour() {
+        let hand = [
+            card(.two, .hearts), card(.three, .hearts), card(.four, .hearts),
+            card(.jack, .spades), card(.nine, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlushType2)
+    }
+
+    // MARK: - SF type 3 variants
+
+    /// 4-6-8 suited: span 4, 2 gaps, 0 high cards → type 3.
+    @Test func threeToStraightFlushType3FourSixEight() {
+        let hand = [
+            card(.four, .diamonds), card(.six, .diamonds), card(.eight, .diamonds),
+            card(.ace, .clubs), card(.three, .hearts),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlushType3)
+    }
+
+    // MARK: - Unsuited TJQK
+
+    /// T-J-Q-K mixed suits: outside straight with 3 high cards (EV 0.87, above low pair).
+    @Test func unsuitedTJQKAllDifferentSuits() {
+        let hand = [
+            card(.ten, .diamonds), card(.jack, .clubs), card(.queen, .spades),
+            card(.king, .hearts), card(.two, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .unsuitedTJQK)
+    }
+
+    /// T-J-Q-K with 3 of one suit: still unsuitedTJQK (not all same suit).
+    @Test func unsuitedTJQKThreeSameSuit() {
+        let hand = [
+            card(.ten, .spades), card(.jack, .spades), card(.queen, .spades),
+            card(.king, .hearts), card(.two, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .unsuitedTJQK)
     }
 }

--- a/Tests/PlayingCardTests/HoldClassifierTests.swift
+++ b/Tests/PlayingCardTests/HoldClassifierTests.swift
@@ -184,6 +184,30 @@ struct HoldClassifierTests {
         #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToStraightFlush)
     }
 
+    // MARK: - Three to Flush (regression cases)
+
+    /// Three suited cards with high-card spread too large for SF draw.
+    /// Regression: previously fell through allSameSuit block and returned twoUnsuitedHighCards.
+    /// Hand: 4d 6c Kc 9h Ac, held 6c Kc Ac (indices 1,2,4).
+    @Test func threeToFlushHighLowMixed() {
+        let hand = [
+            card(.four, .diamonds), card(.six, .clubs), card(.king, .clubs),
+            card(.nine, .hearts), card(.ace, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [1, 2, 4]) == .threeToFlush)
+    }
+
+    /// Three low suited cards not forming any straight flush draw.
+    /// Regression: previously fell through allSameSuit block and returned discardAll.
+    /// Hand: 4c 9h Tc 2d 6c, held 4c Tc 6c (indices 0,2,4).
+    @Test func threeToFlushAllLow() {
+        let hand = [
+            card(.four, .clubs), card(.nine, .hearts), card(.ten, .clubs),
+            card(.two, .diamonds), card(.six, .clubs),
+        ]
+        #expect(classify(hand: hand, holding: [0, 2, 4]) == .threeToFlush)
+    }
+
     // MARK: - Three of a Kind (3-card hold)
 
     @Test func threeOfAKindHeld() {
@@ -464,26 +488,26 @@ struct HoldClassifierPriorityTests {
         #expect(classify(hand: hand, holding: [0, 1, 2, 3]) == .fourToRoyalFlush)
     }
 
-    // MARK: - classifyThree suited fallback fix (Thread 1)
+    // MARK: - Three to flush (three suited, non-royal, non-SF)
 
-    /// Three suited cards that span > 4 and aren't royal-eligible should fall
-    /// through to high-card logic, not be mislabeled as a straight-flush draw.
-    @Test func threeSuitedNonSFDrawFallsToHighCard() {
-        // 2♣ 9♣ K♣: span 11, not a SF draw; K is a high card
+    /// Three suited cards spanning > 4 with one high card → threeToFlush.
+    /// Previously mislabeled as oneHighCard due to suit info being discarded.
+    @Test func threeSuitedNonSFDrawWithHighCard() {
+        // 2♣ 9♣ K♣: span 11, not a SF draw; all clubs → threeToFlush
         let hand = [
             card(.two, .clubs), card(.nine, .clubs), card(.king, .clubs),
             card(.three, .hearts), card(.seven, .spades),
         ]
-        #expect(classify(hand: hand, holding: [0, 1, 2]) == .oneHighCard)
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToFlush)
     }
 
     @Test func threeSuitedNonSFDrawNoHighCard() {
-        // 2♣ 5♣ 9♣: span 7, not a SF draw, no high cards
+        // 2♣ 5♣ 9♣: span 7, not a SF draw, no high cards → threeToFlush
         let hand = [
             card(.two, .clubs), card(.five, .clubs), card(.nine, .clubs),
             card(.king, .hearts), card(.seven, .spades),
         ]
-        #expect(classify(hand: hand, holding: [0, 1, 2]) == .discardAll)
+        #expect(classify(hand: hand, holding: [0, 1, 2]) == .threeToFlush)
     }
 
     // MARK: - canFormStraightFlush wheel fix (Thread 2)

--- a/Tests/PlayingCardTests/HoldClassifierTests.swift
+++ b/Tests/PlayingCardTests/HoldClassifierTests.swift
@@ -208,6 +208,17 @@ struct HoldClassifierTests {
         #expect(classify(hand: hand, holding: [0, 2, 4]) == .threeToFlush)
     }
 
+    /// Three suited cards with one jack and two low cards.
+    /// Regression: previously fell through and returned oneHighCard (saw J, ignored suit).
+    /// Hand: 9h Jc 3c 6c Xd, held Jc 3c 6c.
+    @Test func threeToFlushJackWithLowCards() {
+        let hand = [
+            card(.nine, .hearts), card(.jack, .clubs), card(.three, .clubs),
+            card(.six, .clubs), card(.two, .diamonds),
+        ]
+        #expect(classify(hand: hand, holding: [1, 2, 3]) == .threeToFlush)
+    }
+
     // MARK: - Three of a Kind (3-card hold)
 
     @Test func threeOfAKindHeld() {


### PR DESCRIPTION
## Bug

`classifyThree` fell through the `allSameSuit` block when three suited cards didn't qualify as a royal or SF draw. It entered the unsuited high-card path, silently discarding the suit information.

**User-reported symptoms:**
- 6♣ K♣ A♣ → classified as `twoUnsuitedHighCards` (wrong: they're suited; wrong: three cards not two)
- 4♣ T♣ 6♣ → classified as `discardAll` (wrong: player held three cards)
- J♣ 3♣ 6♣ → classified as `oneHighCard` (wrong: saw J=11, ignored suit)

All three produced coaching text that described patterns the player never used.

## Fix

Add `threeToFlush = "Three to a flush"` to `StrategyPattern`.

In `classifyThree`, when `allSameSuit == true` but neither royal nor SF draw applies, return `.threeToFlush` immediately instead of falling through.

## Tests

3 regression tests added for the exact user-reported hands. 2 existing tests that asserted the old buggy behavior updated to expect `threeToFlush`. All 62 tests pass.