### PR TITLE
Add multiple pay tables and Deuces Wild support

### DIFF
--- a/.github/instructions/swift.instructions.md
+++ b/.github/instructions/swift.instructions.md
@@ -19,6 +19,10 @@ Do not flag small fixed-size array allocations in Swift as defects based on spec
 
 Before flagging a missing `self.` qualifier in a closure, verify that the enclosing type is a class or actor. Swift does not require explicit `self` capture for value types (structs and enums); the requirement is specific to reference types to surface potential retain cycles. If the type is a struct or enum, do not comment on the absence of `self.`.
 
-## Game-Specific vs. General-Purpose APIs
+## Swift Switch Expression Implicit Return
+
+Before flagging a `switch` statement as "missing return" or a compile error, check whether it uses Swift 5.9+ implicit switch-expression syntax: the switch is the sole statement in the function body and each case is a bare expression without an explicit `return` keyword. This is valid Swift and compiles correctly when all enum cases are covered. Only flag missing returns if the switch is not exhaustive (a default case is absent and not all cases are listed) or if explicit `return` statements are mixed inconsistently.
+
+
 
 Before claiming that a function accepting a parameter is "specific to" one game variant or hard-coded to one value, read the full function body and verify that every decision point uses the parameter — not a hard-coded constant. A function is only game-specific if you can cite a specific line where the parameter is ignored and a constant is used in its place. If the implementation uses the parameter throughout, the function is general-purpose regardless of how its return type is named.

--- a/.github/instructions/swift.instructions.md
+++ b/.github/instructions/swift.instructions.md
@@ -18,3 +18,7 @@ Do not flag small fixed-size array allocations in Swift as defects based on spec
 ## Explicit `self.` in Closures
 
 Before flagging a missing `self.` qualifier in a closure, verify that the enclosing type is a class or actor. Swift does not require explicit `self` capture for value types (structs and enums); the requirement is specific to reference types to surface potential retain cycles. If the type is a struct or enum, do not comment on the absence of `self.`.
+
+## Game-Specific vs. General-Purpose APIs
+
+Before claiming that a function accepting a parameter is "specific to" one game variant or hard-coded to one value, read the full function body and verify that every decision point uses the parameter — not a hard-coded constant. A function is only game-specific if you can cite a specific line where the parameter is ignored and a constant is used in its place. If the implementation uses the parameter throughout, the function is general-purpose regardless of how its return type is named.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ let customTable = PayTable(
 
 ```swift
 let engine = OptimalPlay(payTable: .jacksOrBetter96)
-let result = engine.evaluate(hand: cards)
+let result = await engine.evaluate(hand: cards)
 // result.optimalHeld — indices of cards to keep
 // result.optimalEV   — expected value at optimal play
 // result.playerEV    — expected value for a player-chosen hold (if provided)

--- a/README.md
+++ b/README.md
@@ -176,10 +176,54 @@ struct ContentView: View {
 }
 ```
 
-### Video Poker Example
+### Video Poker Pay Tables
+
+Built-in pay tables for common video poker variants:
+
+| Pay Table | Return (optimal) |
+|-----------|-----------------|
+| `PayTable.jacksOrBetter96` | 9/6 Jacks or Better — 99.54% |
+| `PayTable.jacksOrBetter95` | 9/5 Jacks or Better — 98.45% |
+| `PayTable.jacksOrBetter86` | 8/6 Jacks or Better — 98.39% |
+| `PayTable.deucesWild` | Full-Pay Deuces Wild — 100.76% |
+
+Deuces Wild uses all 2s as wild cards. `PayTable.deucesWild` sets `wildcardRank = .two`, which triggers wildcard hand evaluation automatically. New hand types for Deuces Wild: `naturalRoyalFlush`, `fourDeuces`, `wildRoyalFlush`, `fiveOfAKind`.
+
+Custom pay tables:
 
 ```swift
-import PlayingCard
+let customTable = PayTable(
+    name: "8/5 Jacks or Better",
+    multipliers: [
+        .royalFlush: 800,
+        .straightFlush: 50,
+        .fourOfAKind: 25,
+        .fullHouse: 8,
+        .flush: 5,
+        .straight: 4,
+        .threeOfAKind: 3,
+        .twoPair: 2,
+        .jacksOrBetter: 1,
+        .noWin: 0,
+    ],
+)
+```
+
+### Optimal Play Engine
+
+`OptimalPlay` computes the expected value for every possible hold combination and identifies the mathematically optimal hold:
+
+```swift
+let engine = OptimalPlay(payTable: .jacksOrBetter96)
+let result = engine.evaluate(hand: cards)
+// result.optimalHeld — indices of cards to keep
+// result.optimalEV   — expected value at optimal play
+// result.playerEV    — expected value for a player-chosen hold (if provided)
+```
+
+Works with all pay tables including Deuces Wild.
+
+
 
 // Video poker draw scenario
 var deck = Deck()

--- a/Sources/PlayingCard/OptimalPlay.swift
+++ b/Sources/PlayingCard/OptimalPlay.swift
@@ -63,6 +63,10 @@ public struct OptimalPlayResult {
 /// Tie-breaking: when multiple hold sets have identical EV, the one holding more
 /// cards wins (conventional: do not draw from a pat hand unless strictly better).
 ///
+/// Wildcard support: only `wildcardRank == .two` (Deuces Wild) is supported. The fast
+/// inner-loop evaluator hard-codes rank-index 0 for wildcard detection. Passing a pay
+/// table with any other `wildcardRank` will trap at init time.
+///
 /// ## Usage
 ///
 /// ```swift
@@ -80,6 +84,11 @@ public struct OptimalPlay {
     private let isWild: Bool
 
     public init(payTable: PayTable = .jacksOrBetter96) {
+        precondition(
+            payTable.wildcardRank == nil || payTable.wildcardRank == .two,
+            "OptimalPlay only supports wildcardRank == .two (Deuces Wild). "
+                + "The fast evaluator hard-codes rank-index 0 for wild detection.",
+        )
         self.payTable = payTable
         // allCases is declared in rawValue order (0–13), so array index == rawValue.
         multiplierTable = HandResult.allCases.map { payTable.multiplier(for: $0) }

--- a/Sources/PlayingCard/OptimalPlay.swift
+++ b/Sources/PlayingCard/OptimalPlay.swift
@@ -69,15 +69,21 @@ public struct OptimalPlayResult {
 /// let engine = OptimalPlay(payTable: .jacksOrBetter96)
 /// let result = engine.evaluate(hand: cards, playerHeld: [2, 3])
 /// ```
+// swiftlint:disable:next type_body_length
 public struct OptimalPlay {
     public let payTable: PayTable
 
-    /// Payout multipliers indexed by HandResult.rawValue (0–9). Cached for fast access.
+    /// Payout multipliers indexed by HandResult.rawValue (0–13). Cached for fast access.
     private let multiplierTable: [Int]
+
+    /// True when the pay table uses wildcard evaluation (e.g. Deuces Wild).
+    private let isWild: Bool
 
     public init(payTable: PayTable = .jacksOrBetter96) {
         self.payTable = payTable
+        // allCases is declared in rawValue order (0–13), so array index == rawValue.
         multiplierTable = HandResult.allCases.map { payTable.multiplier(for: $0) }
+        isWild = payTable.wildcardRank != nil
     }
 
     /// Evaluates all 32 hold combinations and returns the one with maximum expected value.
@@ -124,7 +130,10 @@ public struct OptimalPlay {
                     .filter { mask & (1 << $0) != 0 }
                     .map { handCodes[$0] }
                 group.addTask {
-                    (mask: mask, ev: fastEV(held: heldCodes, remaining: remaining))
+                    let ev = isWild
+                        ? fastEVWild(held: heldCodes, remaining: remaining)
+                        : fastEV(held: heldCodes, remaining: remaining)
+                    return (mask: mask, ev: ev)
                 }
             }
             var collected: [(mask: Int, ev: Double)] = []
@@ -151,7 +160,9 @@ public struct OptimalPlay {
 
         let playerEV = playerHeld.map { indices -> Double in
             let codes = indices.map { handCodes[$0] }
-            return fastEV(held: codes, remaining: remaining)
+            return isWild
+                ? fastEVWild(held: codes, remaining: remaining)
+                : fastEV(held: codes, remaining: remaining)
         }
 
         return OptimalPlayResult(
@@ -193,7 +204,9 @@ public struct OptimalPlay {
             }
         }
         let heldCodes = holding.sorted().map { handCodes[$0] }
-        return fastEV(held: heldCodes, remaining: remaining)
+        return isWild
+            ? fastEVWild(held: heldCodes, remaining: remaining)
+            : fastEV(held: heldCodes, remaining: remaining)
     }
 
     // MARK: - Fast Inner Loop
@@ -390,6 +403,371 @@ public struct OptimalPlay {
         }
 
         return HandResult.noWin.rawValue
+    }
+
+    // MARK: - Deuces Wild inner loop
+
+    /// `fastEV` variant for Deuces Wild. Dispatches hand evaluation through
+    /// `handResultCodeDeuces` which treats rank_index 0 (the 2) as a wildcard.
+    private func fastEVWild(held: [Int], remaining: [Int]) -> Double {
+        let drawCount = 5 - held.count
+        let count = remaining.count
+        var total = 0
+
+        switch drawCount {
+        case 0:
+            return Double(
+                multiplierTable[
+                    handResultCodeDeuces(held[0], held[1], held[2], held[3], held[4]),
+                ],
+            )
+
+        case 1:
+            let h0 = held[0], h1 = held[1], h2 = held[2], h3 = held[3]
+            for i in 0 ..< count {
+                total += multiplierTable[handResultCodeDeuces(h0, h1, h2, h3, remaining[i])]
+            }
+            return Double(total) / Double(count)
+
+        case 2:
+            let h0 = held[0], h1 = held[1], h2 = held[2]
+            for i in 0 ..< count - 1 {
+                let card0 = remaining[i]
+                for j in i + 1 ..< count {
+                    total += multiplierTable[handResultCodeDeuces(h0, h1, h2, card0, remaining[j])]
+                }
+            }
+            let comboCount = (count * (count - 1)) / 2
+            return Double(total) / Double(comboCount)
+
+        case 3:
+            let h0 = held[0], h1 = held[1]
+            for i in 0 ..< count - 2 {
+                let card0 = remaining[i]
+                for j in i + 1 ..< count - 1 {
+                    let card1 = remaining[j]
+                    for k in j + 1 ..< count {
+                        total += multiplierTable[
+                            handResultCodeDeuces(h0, h1, card0, card1, remaining[k]),
+                        ]
+                    }
+                }
+            }
+            let comboCount = (count * (count - 1) * (count - 2)) / 6
+            return Double(total) / Double(comboCount)
+
+        case 4:
+            let h0 = held[0]
+            for i in 0 ..< count - 3 {
+                let card0 = remaining[i]
+                for j in i + 1 ..< count - 2 {
+                    let card1 = remaining[j]
+                    for k in j + 1 ..< count - 1 {
+                        let card2 = remaining[k]
+                        for l in k + 1 ..< count {
+                            total += multiplierTable[
+                                handResultCodeDeuces(h0, card0, card1, card2, remaining[l]),
+                            ]
+                        }
+                    }
+                }
+            }
+            let comboCount = (count * (count - 1) * (count - 2) * (count - 3)) / 24
+            return Double(total) / Double(comboCount)
+
+        case 5:
+            for i in 0 ..< count - 4 {
+                let card0 = remaining[i]
+                for j in i + 1 ..< count - 3 {
+                    let card1 = remaining[j]
+                    for k in j + 1 ..< count - 2 {
+                        let card2 = remaining[k]
+                        for l in k + 1 ..< count - 1 {
+                            let card3 = remaining[l]
+                            for m in l + 1 ..< count {
+                                total += multiplierTable[
+                                    handResultCodeDeuces(card0, card1, card2, card3, remaining[m]),
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+            let comboCount =
+                (count * (count - 1) * (count - 2) * (count - 3) * (count - 4)) / 120
+            return Double(total) / Double(comboCount)
+
+        default:
+            preconditionFailure("drawCount must be 0–5, got \(drawCount)")
+        }
+    }
+
+    /// Deuces Wild hand evaluator. Treats rank_index 0 (the physical 2) as a wildcard that
+    /// substitutes for any card (any rank and suit).
+    ///
+    /// Evaluation priority: naturalRoyalFlush > fourDeuces > wildRoyalFlush > fiveOfAKind >
+    /// straightFlush > fourOfAKind > fullHouse > flush > straight > threeOfAKind > noWin.
+    ///
+    /// For k=0, delegates to `handResultCode` and remaps the result to DW conventions
+    /// (royal flush → naturalRoyalFlush; pair/two-pair → noWin).
+    @inline(__always)
+    private func handResultCodeDeuces(
+        _ c0: Int, _ c1: Int, _ c2: Int, _ c3: Int, _ c4: Int,
+    ) -> Int {
+        // rank_index 0 = deuce = wild.
+        let r0 = c0 >> 2, r1 = c1 >> 2, r2 = c2 >> 2, r3 = c3 >> 2, r4 = c4 >> 2
+
+        // Count wildcards.
+        let k = (r0 == 0 ? 1 : 0) + (r1 == 0 ? 1 : 0) + (r2 == 0 ? 1 : 0)
+            + (r3 == 0 ? 1 : 0) + (r4 == 0 ? 1 : 0)
+
+        // k=4: Four Deuces.
+        if k == 4 {
+            return HandResult.fourDeuces.rawValue
+        }
+
+        // k=0: Standard JoB evaluation with DW remapping.
+        if k == 0 {
+            let base = handResultCode(c0, c1, c2, c3, c4)
+            if base == HandResult.royalFlush.rawValue {
+                return HandResult.naturalRoyalFlush.rawValue
+            }
+            // Pair (jacksOrBetter=1) and two-pair (2) don't pay in DW.
+            return base <= 2 ? HandResult.noWin.rawValue : base
+        }
+
+        // k = 1, 2, or 3 — extract natural (non-wild) cards into fixed slots.
+        // n = 5 - k  (guaranteed 2–4 naturals).
+        // c0 is first: if r0 != 0, n is always 0 before this block.
+        var na0 = 0, na1 = 0, na2 = 0, na3 = 0 // natural rank indices
+        var ns0 = 0, ns1 = 0, ns2 = 0, ns3 = 0 // natural suit indices
+        var n = 0
+
+        if r0 != 0 {
+            na0 = r0; ns0 = c0 & 3; n = 1
+        }
+        if r1 != 0 {
+            switch n {
+            case 0: na0 = r1; ns0 = c1 & 3
+            case 1: na1 = r1; ns1 = c1 & 3
+            default: na2 = r1; ns2 = c1 & 3
+            }
+            n += 1
+        }
+        if r2 != 0 {
+            switch n {
+            case 0: na0 = r2; ns0 = c2 & 3
+            case 1: na1 = r2; ns1 = c2 & 3
+            case 2: na2 = r2; ns2 = c2 & 3
+            default: na3 = r2; ns3 = c2 & 3
+            }
+            n += 1
+        }
+        if r3 != 0 {
+            switch n {
+            case 0: na0 = r3; ns0 = c3 & 3
+            case 1: na1 = r3; ns1 = c3 & 3
+            case 2: na2 = r3; ns2 = c3 & 3
+            default: na3 = r3; ns3 = c3 & 3
+            }
+            n += 1
+        }
+        if r4 != 0 {
+            switch n {
+            case 0: na0 = r4; ns0 = c4 & 3
+            case 1: na1 = r4; ns1 = c4 & 3
+            case 2: na2 = r4; ns2 = c4 & 3
+            default: na3 = r4; ns3 = c4 & 3
+            }
+            n += 1
+        }
+
+        // Compute per-rank frequencies and distinct-rank count without allocation.
+        // Slots d0–d3 hold distinct rank values; f0–f3 hold their frequencies.
+        var d0 = -1, d1 = -1, d2 = -1, d3 = -1
+        var f0 = 0, f1 = 0, f2 = 0, f3 = 0
+        var dCount = 0
+
+        func countRank(_ r: Int) {
+            if r == d0 {
+                f0 += 1; return
+            }
+            if d0 == -1 {
+                d0 = r; f0 = 1; dCount = 1; return
+            }
+            if r == d1 {
+                f1 += 1; return
+            }
+            if d1 == -1 {
+                d1 = r; f1 = 1; dCount = 2; return
+            }
+            if r == d2 {
+                f2 += 1; return
+            }
+            if d2 == -1 {
+                d2 = r; f2 = 1; dCount = 3; return
+            }
+            if r == d3 {
+                f3 += 1; return
+            }
+            if d3 == -1 {
+                d3 = r; f3 = 1; dCount = 4; return
+            }
+        }
+
+        countRank(na0)
+        countRank(na1)
+        if n > 2 {
+            countRank(na2)
+        }
+        if n > 3 {
+            countRank(na3)
+        }
+
+        let maxFreq = max(f0, max(f1, max(f2, f3)))
+
+        // Wild Royal Flush: all naturals are royal (rank_idx 8–12 = T through A),
+        // all same suit, all distinct ranks. Wildcards fill remaining royal slots.
+        // n + k = 5 always, so wilds always fill exactly the missing royal positions.
+        if maxFreq == 1 { // distinct check shortcut: if all freqs are 1, ranks are distinct
+            let allRoyal = na0 >= 8 && na1 >= 8 && (n < 3 || na2 >= 8) && (n < 4 || na3 >= 8)
+            if allRoyal {
+                let suit = ns0
+                let allSameSuit =
+                    ns1 == suit && (n < 3 || ns2 == suit) && (n < 4 || ns3 == suit)
+                if allSameSuit {
+                    return HandResult.wildRoyalFlush.rawValue
+                }
+            }
+        }
+
+        // Five of a Kind: most-frequent rank + wildcards ≥ 5.
+        if maxFreq + k >= 5 {
+            return HandResult.fiveOfAKind.rawValue
+        }
+
+        // Straight Flush: all naturals share a suit, distinct ranks, fit in a 5-card window.
+        let sfSuit = ns0
+        let allSameSuit =
+            ns1 == sfSuit && (n < 3 || ns2 == sfSuit) && (n < 4 || ns3 == sfSuit)
+        if allSameSuit {
+            // distinct means dCount == n (all different ranks).
+            let rankDistinct = dCount == n
+            if rankDistinct {
+                if dwCanFormStraightWindow(na0, na1, na2, na3, n: n) {
+                    return HandResult.straightFlush.rawValue
+                }
+            }
+        }
+
+        // Four of a Kind.
+        if maxFreq + k >= 4 {
+            return HandResult.fourOfAKind.rawValue
+        }
+
+        // Full House: at most 2 distinct natural ranks, wilds fill the gaps.
+        if dCount <= 2 {
+            var sortF1 = f0, sortF2 = f1
+            if dCount == 1 {
+                sortF2 = 0
+            }
+            if sortF1 < sortF2 {
+                let t = sortF1; sortF1 = sortF2; sortF2 = t
+            }
+            let wildsA = max(0, 3 - sortF1) + max(0, 2 - sortF2)
+            let wildsB = max(0, 2 - sortF1) + max(0, 3 - sortF2)
+            if min(wildsA, wildsB) <= k {
+                return HandResult.fullHouse.rawValue
+            }
+        }
+
+        // Flush: all naturals same suit (SF already failed, so no straight window).
+        if allSameSuit {
+            return HandResult.flush.rawValue
+        }
+
+        // Straight: distinct natural ranks fit in a 5-card window (suit-agnostic).
+        if dCount == n { // all distinct
+            if dwCanFormStraightWindow(na0, na1, na2, na3, n: n) {
+                return HandResult.straight.rawValue
+            }
+        }
+
+        // Three of a Kind: most-frequent rank + wildcards ≥ 3.
+        if maxFreq + k >= 3 {
+            return HandResult.threeOfAKind.rawValue
+        }
+
+        return HandResult.noWin.rawValue
+    }
+
+    /// Returns true when `n` natural rank indices (na0…na(n-1)) fit inside a 5-card
+    /// straight window using wildcards to fill the remaining positions.
+    ///
+    /// Handles both the standard case (span ≤ 4) and the wheel A-2-3-4-5
+    /// (rank_index 12 = Ace, with the 2 being wild and naturals in {1,2,3} = ranks 3,4,5).
+    @inline(__always)
+    private func dwCanFormStraightWindow(
+        _ na0: Int, _ na1: Int, _ na2: Int, _ na3: Int, n: Int,
+    ) -> Bool {
+        var lo = na0, hi = na0
+        if na1 < lo {
+            lo = na1
+        } else if na1 > hi {
+            hi = na1
+        }
+        if n > 2 {
+            if na2 < lo {
+                lo = na2
+            } else if na2 > hi {
+                hi = na2
+            }
+        }
+        if n > 3 {
+            if na3 < lo {
+                lo = na3
+            } else if na3 > hi {
+                hi = na3
+            }
+        }
+
+        let span = hi - lo
+        if span <= 4 {
+            return true
+        }
+
+        // Wheel: Ace (rank_index 12) + naturals in {1, 2, 3} (actual ranks 3–5).
+        // The 2 (rank_index 0) is always wild, so naturals can't contribute rank_index 0.
+        if hi == 12 { // ace present
+            let nonAceOK =
+                dwAllInWheelRange(na0, na1, na2, na3, n: n, lo: lo)
+            if nonAceOK {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Returns true when all non-ace natural ranks (rank_idx != 12) are in [1, 3].
+    @inline(__always)
+    private func dwAllInWheelRange(
+        _ na0: Int, _ na1: Int, _ na2: Int, _ na3: Int, n: Int, lo: Int,
+    ) -> Bool {
+        /// lo is the minimum rank_index; if lo == 12 all cards are aces (impossible for n>1).
+        func inRange(_ r: Int) -> Bool {
+            r == 12 || (r >= 1 && r <= 3)
+        }
+        if !inRange(na0) || !inRange(na1) {
+            return false
+        }
+        if n > 2, !inRange(na2) {
+            return false
+        }
+        if n > 3, !inRange(na3) {
+            return false
+        }
+        _ = lo
+        return true
     }
 
     // swiftlint:enable identifier_name cyclomatic_complexity function_body_length

--- a/Sources/PlayingCard/PayTable.swift
+++ b/Sources/PlayingCard/PayTable.swift
@@ -1,10 +1,18 @@
 import Foundation
 
-/// The video-poker-specific result of a 5-card hand under a Jacks or Better pay table.
+/// The video-poker-specific result of a 5-card hand.
 ///
-/// Differs from `HandType` in two ways: a non-qualifying pair (lower than Jacks) maps to
-/// `.noWin`, and `.highCard` is also `.noWin`. All other hand types map one-to-one.
+/// Covers both Jacks or Better and Deuces Wild variants. For Jacks or Better, a
+/// non-qualifying pair maps to `.noWin` and `.highCard` maps to `.noWin`. For Deuces
+/// Wild, pairs and two-pair also map to `.noWin`; the minimum winning hand is
+/// `.threeOfAKind`. Wild-card-specific hands (`.fiveOfAKind`, `.wildRoyalFlush`,
+/// `.fourDeuces`, `.naturalRoyalFlush`) appear only in Deuces Wild evaluation.
+///
+/// Raw values define the ordering used by `Comparable` and by `OptimalPlay`'s
+/// internal multiplier lookup. All cases are ordered weakest-to-strongest.
 public enum HandResult: Int, CaseIterable, Comparable, CustomStringConvertible {
+    // MARK: - Standard hands (rawValues 0–9, used in Jacks or Better and Deuces Wild)
+
     case noWin = 0
     case jacksOrBetter = 1
     case twoPair = 2
@@ -14,7 +22,20 @@ public enum HandResult: Int, CaseIterable, Comparable, CustomStringConvertible {
     case fullHouse = 6
     case fourOfAKind = 7
     case straightFlush = 8
+    /// A natural (no-wild) royal flush. Used by Jacks or Better pay tables.
+    /// For Deuces Wild, use `.naturalRoyalFlush` (rawValue 13).
     case royalFlush = 9
+
+    // MARK: - Deuces Wild additions (rawValues 10–13)
+
+    /// Five cards of the same rank (requires at least one wild). Pays 15x in full-pay Deuces Wild.
+    case fiveOfAKind = 10
+    /// A royal flush made with at least one wild deuce. Pays 25x in full-pay Deuces Wild.
+    case wildRoyalFlush = 11
+    /// Four deuces in hand. Pays 200x in full-pay Deuces Wild.
+    case fourDeuces = 12
+    /// A natural royal flush (no wild deuces used). Pays 800x in full-pay Deuces Wild.
+    case naturalRoyalFlush = 13
 
     public static func < (lhs: HandResult, rhs: HandResult) -> Bool {
         lhs.rawValue < rhs.rawValue
@@ -32,19 +53,43 @@ public enum HandResult: Int, CaseIterable, Comparable, CustomStringConvertible {
         case .fourOfAKind: "Four of a Kind"
         case .straightFlush: "Straight Flush"
         case .royalFlush: "Royal Flush"
+        case .fiveOfAKind: "Five of a Kind"
+        case .wildRoyalFlush: "Wild Royal Flush"
+        case .fourDeuces: "Four Deuces"
+        case .naturalRoyalFlush: "Natural Royal Flush"
         }
     }
 
-    /// True when the hand pays out at least 1x.
+    /// True when the hand pays out at least 1x under any supported pay table.
     public var isWin: Bool {
         self != .noWin
     }
 
     /// Classifies a 5-card hand into its video poker result.
     ///
-    /// Returns `.noWin` for incomplete hands, non-qualifying pairs, and high-card hands.
-    public static func evaluate(cards: [PlayingCard]) -> HandResult {
+    /// - Parameters:
+    ///   - cards: Exactly 5 cards.
+    ///   - wildcardRank: When non-nil, cards of this rank act as wild cards (Deuces Wild: `.two`).
+    ///     Pass `nil` for Jacks or Better evaluation.
+    ///
+    /// For Jacks or Better (`wildcardRank == nil`): returns `.noWin` for incomplete hands,
+    /// non-qualifying pairs, and high-card hands. Returns `.royalFlush` for a natural royal.
+    ///
+    /// For Deuces Wild (`wildcardRank == .two`): returns `.naturalRoyalFlush` for a natural royal,
+    /// `.fourDeuces` / `.wildRoyalFlush` / `.fiveOfAKind` for wild-enhanced hands, and `.noWin`
+    /// for pairs, two-pair, and high-card hands.
+    public static func evaluate(cards: [PlayingCard], wildcardRank: Rank? = nil) -> HandResult {
         guard cards.count == 5 else { return .noWin }
+
+        guard let wildcardRank else {
+            return evaluateJacksOrBetter(cards: cards)
+        }
+        return evaluateWithWilds(cards: cards, wildcardRank: wildcardRank)
+    }
+
+    // MARK: - Private evaluation helpers
+
+    private static func evaluateJacksOrBetter(cards: [PlayingCard]) -> HandResult {
         switch Hand(cards: cards).evaluate() {
         case .royalFlush: return .royalFlush
         case .straightFlush: return .straightFlush
@@ -79,6 +124,160 @@ public enum HandResult: Int, CaseIterable, Comparable, CustomStringConvertible {
             return .noWin
         }
     }
+
+    /// Evaluates a 5-card hand where cards of `wildcardRank` are wild.
+    ///
+    // swiftlint:disable identifier_name cyclomatic_complexity
+    /// Returns the highest-paying hand achievable by substituting wildcards optimally.
+    /// Hand priority (high to low): naturalRoyalFlush > fourDeuces > wildRoyalFlush >
+    /// fiveOfAKind > straightFlush > fourOfAKind > fullHouse > flush > straight >
+    /// threeOfAKind > noWin.
+    private static func evaluateWithWilds(cards: [PlayingCard], wildcardRank: Rank) -> HandResult {
+        let wilds = cards.filter { $0.rank == wildcardRank }
+        let naturals = cards.filter { $0.rank != wildcardRank }
+        let k = wilds.count
+        let n = naturals.count
+
+        // Four wilds: second-highest hand in Deuces Wild.
+        if k == 4 {
+            return .fourDeuces
+        }
+
+        // No wilds: standard evaluation with DW remapping.
+        if k == 0 {
+            switch Hand(cards: cards).evaluate() {
+            case .royalFlush: return .naturalRoyalFlush
+            case .straightFlush: return .straightFlush
+            case .fourOfAKind: return .fourOfAKind
+            case .fullHouse: return .fullHouse
+            case .flush: return .flush
+            case .straight: return .straight
+            case .threeOfAKind: return .threeOfAKind
+            case .twoPair, .pair, .highCard: return .noWin
+            }
+        }
+
+        // k = 1, 2, or 3. n = 4, 3, or 2 respectively.
+        let natRanks = naturals.map(\.rank)
+        let natSuits = naturals.map(\.suit)
+
+        // Wild Royal Flush: all naturals are in {T,J,Q,K,A} of the same suit, distinct ranks.
+        // With k wilds filling the remaining royal positions.
+        if n > 0 {
+            let allRoyal = natRanks.allSatisfy { $0.rawValue >= 10 }
+            if allRoyal {
+                let allSameSuit = natSuits.dropFirst().allSatisfy { $0 == natSuits[0] }
+                let allDistinct = Set(natRanks).count == n
+                if allSameSuit, allDistinct {
+                    return .wildRoyalFlush
+                }
+            }
+        }
+
+        // Five of a Kind: most-common natural rank + k wildcards ≥ 5.
+        let rankFreqs = Dictionary(grouping: natRanks, by: { $0 }).mapValues(\.count)
+        let maxFreq = rankFreqs.values.max() ?? 0
+        if maxFreq + k >= 5 {
+            return .fiveOfAKind
+        }
+
+        // Straight Flush: all naturals same suit, distinct ranks that fit in a 5-card window.
+        if n > 0 {
+            let sfSuit = natSuits[0]
+            let allSameSuit = natSuits.dropFirst().allSatisfy { $0 == sfSuit }
+            if allSameSuit {
+                let allDistinct = Set(natRanks).count == n
+                if allDistinct {
+                    let rawValues = natRanks.map(\.rawValue).sorted()
+                    if canFormStraightWindow(sortedRawValues: rawValues, wildcardRank: wildcardRank) {
+                        return .straightFlush
+                    }
+                }
+            }
+        }
+
+        // Four of a Kind: most-common natural rank + k wildcards ≥ 4.
+        if maxFreq + k >= 4 {
+            return .fourOfAKind
+        }
+
+        // Full House: naturals split into at most 2 distinct ranks, wilds fill the gaps.
+        if canFormFullHouse(natRanks: natRanks, wildcardCount: k) {
+            return .fullHouse
+        }
+
+        // Flush: all naturals same suit (SF already failed, so ranks aren't consecutive).
+        if n > 0 {
+            let flushSuit = natSuits[0]
+            if natSuits.dropFirst().allSatisfy({ $0 == flushSuit }) {
+                return .flush
+            }
+        }
+
+        // Straight: distinct natural ranks fit in a 5-card window (suits ignored).
+        if n > 0 {
+            let allDistinct = Set(natRanks).count == n
+            if allDistinct {
+                let rawValues = natRanks.map(\.rawValue).sorted()
+                if canFormStraightWindow(sortedRawValues: rawValues, wildcardRank: wildcardRank) {
+                    return .straight
+                }
+            }
+        }
+
+        // Three of a Kind: most-common natural rank + k wildcards ≥ 3.
+        if maxFreq + k >= 3 {
+            return .threeOfAKind
+        }
+
+        return .noWin
+    }
+
+    /// Returns true if `sortedRawValues` (natural card ranks) fit inside a 5-card straight
+    /// window when `k` wildcards fill the remaining slots. Handles the wheel (A-2-3-4-5) where
+    /// the 2 is the wildcard rank.
+    ///
+    /// - Parameters:
+    ///   - sortedRawValues: Ascending-sorted raw rank values of the natural cards.
+    ///   - wildcardRank: The wild rank (used to detect wheel-draw edge cases).
+    private static func canFormStraightWindow(sortedRawValues: [Int], wildcardRank: Rank) -> Bool {
+        guard !sortedRawValues.isEmpty else { return true }
+        let span = sortedRawValues.last! - sortedRawValues.first!
+        // Standard window: span ≤ 4 covers any 5-card straight (non-wheel).
+        if span <= 4 {
+            return true
+        }
+        // Wheel: A + subset of {3,4,5} (2 is wild, so naturals can't contribute the 2 slot).
+        if sortedRawValues.last == 14 { // ace present
+            let nonAce = sortedRawValues.dropLast()
+            let wildcardRV = wildcardRank.rawValue
+            // Non-ace ranks must all be in [3, 5] excluding the wildcard rank.
+            if nonAce.allSatisfy({ $0 >= 3 && $0 <= 5 && $0 != wildcardRV }) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Returns true if the natural cards can be arranged as a full house (3+2) when
+    /// `wilds` wildcards fill the remaining slots, given that all naturals must participate.
+    ///
+    /// Requires at most 2 distinct natural ranks (a third rank can't fit into 3+2).
+    private static func canFormFullHouse(natRanks: [Rank], wildcardCount: Int) -> Bool {
+        let rankFreqs = Dictionary(grouping: natRanks, by: { $0 }).mapValues(\.count)
+        guard rankFreqs.count <= 2 else { return false }
+
+        let freqs = rankFreqs.values.sorted(by: >)
+        let f1 = freqs.first ?? 0
+        let f2 = freqs.count > 1 ? freqs[1] : 0
+
+        // Option A: rank1 → trips, rank2 → pair.
+        let wildsA = max(0, 3 - f1) + max(0, 2 - f2)
+        // Option B: rank1 → pair, rank2 → trips.
+        let wildsB = max(0, 2 - f1) + max(0, 3 - f2)
+        return min(wildsA, wildsB) <= wildcardCount
+    }
+    // swiftlint:enable identifier_name cyclomatic_complexity
 }
 
 /// A video poker pay table mapping hand results to coin multipliers.
@@ -88,9 +287,16 @@ public struct PayTable {
 
     private let multipliers: [HandResult: Int]
 
-    public init(name: String, multipliers: [HandResult: Int]) {
+    /// When non-nil, cards of this rank act as wild cards during hand evaluation.
+    ///
+    /// Set to `.two` for Deuces Wild pay tables. The `handResult(for:)` and related
+    /// methods automatically pass this to `HandResult.evaluate(cards:wildcardRank:)`.
+    public let wildcardRank: Rank?
+
+    public init(name: String, multipliers: [HandResult: Int], wildcardRank: Rank? = nil) {
         self.name = name
         self.multipliers = multipliers
+        self.wildcardRank = wildcardRank
     }
 
     /// The payout multiplier for a given hand result.
@@ -102,17 +308,20 @@ public struct PayTable {
     }
 
     /// Evaluates the cards and returns their `HandResult`.
+    ///
+    /// Uses wildcard evaluation when `wildcardRank` is set.
     public func handResult(for cards: [PlayingCard]) -> HandResult {
-        HandResult.evaluate(cards: cards)
+        HandResult.evaluate(cards: cards, wildcardRank: wildcardRank)
     }
 
     /// Total coins returned for the given bet. `bet` must be 1-5.
     ///
-    /// Royal flush pays 800x at bet=5 (4000 total) and 250x at bet 1-4.
+    /// Royal flush (`.royalFlush` or `.naturalRoyalFlush`) pays 800x at bet=5 (4000 total)
+    /// and 250x at bet 1-4.
     public func payout(for cards: [PlayingCard], bet: Int = 5) -> Int {
         precondition((1 ... 5).contains(bet), "bet must be between 1 and 5")
         let result = handResult(for: cards)
-        if result == .royalFlush, bet != 5 {
+        if result == .royalFlush || result == .naturalRoyalFlush, bet != 5 {
             return 250 * bet
         }
         return multiplier(for: result) * bet
@@ -124,7 +333,11 @@ public struct PayTable {
         return payout(for: cards, bet: bet) - bet
     }
 
+    // MARK: - Static pay tables
+
     /// Full-pay 9/6 Jacks or Better. Returns 99.54% with optimal play.
+    ///
+    /// Named for the full house (9) and flush (6) payouts that define this variant.
     public static let jacksOrBetter96 = PayTable(
         name: "Jacks or Better (9/6)",
         multipliers: [
@@ -139,5 +352,61 @@ public struct PayTable {
             .jacksOrBetter: 1,
             .noWin: 0,
         ],
+    )
+
+    /// 9/5 Jacks or Better (flush pays 5 instead of 6). Returns 98.45% with optimal play.
+    public static let jacksOrBetter95 = PayTable(
+        name: "Jacks or Better (9/5)",
+        multipliers: [
+            .royalFlush: 800,
+            .straightFlush: 50,
+            .fourOfAKind: 25,
+            .fullHouse: 9,
+            .flush: 5,
+            .straight: 4,
+            .threeOfAKind: 3,
+            .twoPair: 2,
+            .jacksOrBetter: 1,
+            .noWin: 0,
+        ],
+    )
+
+    /// 8/6 Jacks or Better (full house pays 8 instead of 9). Returns 98.39% with optimal play.
+    public static let jacksOrBetter86 = PayTable(
+        name: "Jacks or Better (8/6)",
+        multipliers: [
+            .royalFlush: 800,
+            .straightFlush: 50,
+            .fourOfAKind: 25,
+            .fullHouse: 8,
+            .flush: 6,
+            .straight: 4,
+            .threeOfAKind: 3,
+            .twoPair: 2,
+            .jacksOrBetter: 1,
+            .noWin: 0,
+        ],
+    )
+
+    /// Full-pay Deuces Wild. Returns 100.76% with optimal play.
+    ///
+    /// All 2s are wild. Pairs and two-pair do not pay. Minimum winning hand is three of a kind.
+    /// Natural royal flush pays 800x (same bonus convention as Jacks or Better at max bet).
+    public static let deucesWild = PayTable(
+        name: "Deuces Wild (Full Pay)",
+        multipliers: [
+            .naturalRoyalFlush: 800,
+            .fourDeuces: 200,
+            .wildRoyalFlush: 25,
+            .fiveOfAKind: 15,
+            .straightFlush: 9,
+            .fourOfAKind: 5,
+            .fullHouse: 3,
+            .flush: 2,
+            .straight: 2,
+            .threeOfAKind: 1,
+            .noWin: 0,
+        ],
+        wildcardRank: .two,
     )
 }

--- a/Sources/PlayingCard/PayTable.swift
+++ b/Sources/PlayingCard/PayTable.swift
@@ -43,7 +43,7 @@ public enum HandResult: Int, CaseIterable, Comparable, CustomStringConvertible {
 
     public var description: String {
         switch self {
-        case .noWin: "No Win"
+        case .noWin: "No Winner"
         case .jacksOrBetter: "Jacks or Better"
         case .twoPair: "Two Pair"
         case .threeOfAKind: "Three of a Kind"

--- a/Sources/PlayingCard/StrategyPattern.swift
+++ b/Sources/PlayingCard/StrategyPattern.swift
@@ -75,6 +75,45 @@ public enum StrategyPattern: String, Equatable, CaseIterable, Sendable {
     case oneHighCard = "One high card"
     /// No cards held.
     case discardAll = "Discard all"
+
+    // MARK: - Deuces Wild patterns
+
+    /// All four deuces held — already the second-highest winning hand.
+    case fourDeuces = "Four deuces"
+    /// Three deuces + two natural royals of the same suit forming a wild royal flush.
+    case patWildRoyalFlush = "Pat wild royal flush"
+    /// Three deuces held; no pat royal flush possible.
+    case threeDeuces = "Three deuces"
+    /// Two deuces + a pat hand (four of a kind or better, including wild royal or five of a kind).
+    case patHandTwoDeuces = "Pat hand (two deuces)"
+    /// Two deuces + four cards to a royal flush (deuce fills the fifth royal slot).
+    case fourToRoyalFlushTwoDeuces = "Four to a royal flush (two deuces)"
+    /// Two deuces + three consecutive naturals 6 or higher forming a straight-flush draw.
+    case fourToStraightFlushTwoDeuces = "Four to a straight flush (two deuces)"
+    /// Two deuces only — hold the pair of deuces and draw three.
+    case twoDeuces = "Two deuces"
+    /// One deuce + a pat hand (four of a kind or better).
+    case patHandOneDeuce = "Pat hand (one deuce)"
+    /// One deuce + four naturals completing a royal flush draw.
+    case fourToRoyalFlushOneDeuce = "Four to a royal flush (one deuce)"
+    /// One deuce + a pat full house.
+    case patFullHouseOneDeuce = "Pat full house (one deuce)"
+    /// One deuce + three consecutive naturals ranked 5 or higher, forming a high SF draw.
+    case fourToStraightFlushHighOneDeuce = "Four to a straight flush, 3 consecutive 5+ (one deuce)"
+    /// One deuce + a pat three of a kind, straight, or flush.
+    case patLowHandOneDeuce = "Pat three of a kind, straight, or flush (one deuce)"
+    /// One deuce + four cards to any other straight flush draw.
+    case fourToStraightFlushOneDeuce = "Four to a straight flush (one deuce)"
+    /// One deuce + three naturals to a royal flush.
+    case threeToRoyalFlushOneDeuce = "Three to a royal flush (one deuce)"
+    /// One deuce + two consecutive naturals ranked 6 or higher forming a SF draw.
+    case threeToStraightFlushHighOneDeuce = "Three to a straight flush, 2 consecutive 6+ (one deuce)"
+    /// One deuce only — hold only the deuce and draw four.
+    case oneDeuce = "One deuce"
+    /// Any pair (no distinction between high/low in Deuces Wild; pairs don't pay).
+    case pair = "Pair"
+    /// Two suited cards both J or higher (Deuces Wild 0-deuce position 10).
+    case twoToRoyalFlushJQHigh = "Two to a royal flush (J/Q high)"
 }
 
 // MARK: - HoldClassifier
@@ -87,6 +126,7 @@ public enum StrategyPattern: String, Equatable, CaseIterable, Sendable {
 /// let pattern = HoldClassifier.classify(hand: dealtCards, holding: [0, 2, 4])
 /// print(pattern.rawValue) // e.g. "Three to a royal flush"
 /// ```
+// swiftlint:disable:next type_body_length
 public struct HoldClassifier {
     private init() {}
 
@@ -411,5 +451,250 @@ public struct HoldClassifier {
             consecutivePairs += 1
         }
         return consecutivePairs == 2
+    }
+
+    // MARK: - Deuces Wild classification
+
+    /// Returns the highest-priority Deuces Wild strategy pattern for the given hold set.
+    ///
+    /// All 2s (deuces) in the held cards are treated as wild. The pattern reflects
+    /// the WoO simple-strategy hierarchy, broken into sections by deuce count.
+    ///
+    /// - Parameters:
+    ///   - hand: Exactly 5 dealt cards.
+    ///   - holding: Indices (0–4) the player chose to hold.
+    public static func classifyDeucesWild(hand: [PlayingCard], holding: Set<Int>) -> StrategyPattern {
+        precondition(hand.count == 5, "HoldClassifier requires exactly 5 dealt cards")
+        precondition(
+            holding.allSatisfy { (0 ..< 5).contains($0) },
+            "holding indices must be in 0...4",
+        )
+
+        let held = holding.sorted().map { hand[$0] }
+        let deuces = held.filter { $0.rank == .two }
+        let naturals = held.filter { $0.rank != .two }
+        let deuceCount = deuces.count
+
+        switch deuceCount {
+        case 4: return .fourDeuces
+        case 3: return classifyDW3Deuces(naturals: naturals)
+        case 2: return classifyDW2Deuces(naturals: naturals, allHeld: held)
+        case 1: return classifyDW1Deuce(naturals: naturals, allHeld: held)
+        default: return classifyDW0Deuces(held: held)
+        }
+    }
+
+    // MARK: 3 deuces
+
+    private static func classifyDW3Deuces(naturals: [PlayingCard]) -> StrategyPattern {
+        guard naturals.count == 2 else { return .threeDeuces }
+        let ranks = naturals.map(\.rank.rawValue)
+        let suits = naturals.map(\.suit)
+        // Pat wild royal: both naturals are distinct royal cards (T–A) of the same suit.
+        if ranks.allSatisfy({ $0 >= 10 }), Set(ranks).count == 2, suits[0] == suits[1] {
+            return .patWildRoyalFlush
+        }
+        return .threeDeuces
+    }
+
+    // MARK: 2 deuces
+
+    private static func classifyDW2Deuces(naturals: [PlayingCard], allHeld: [PlayingCard]) -> StrategyPattern {
+        // Pat hand (4+ cards held = 2 deuces + 3 naturals evaluates as 5-card hand).
+        if allHeld.count == 5 {
+            let result = HandResult.evaluate(cards: allHeld, wildcardRank: .two)
+            if result >= .fourOfAKind {
+                return .patHandTwoDeuces
+            }
+        }
+        // Partial holds: 2 deuces + 1 natural = 3 held cards total.
+        if naturals.count == 1 {
+            let natural = naturals[0]
+            // 4 to a royal: deuce + deuce + royal card = need 1 natural to be in {T–A}.
+            // With 2 deuces + 1 royal natural, drawing 2 can complete a wild RF.
+            if natural.rank.rawValue >= 10 {
+                return .fourToRoyalFlushTwoDeuces
+            }
+        }
+        // 2 deuces + 2 naturals.
+        if naturals.count == 2 {
+            let ranks = naturals.map(\.rank.rawValue).sorted()
+            let suits = naturals.map(\.suit)
+            // 4 to a royal flush: both naturals are distinct royal cards of same suit.
+            if ranks.allSatisfy({ $0 >= 10 }), Set(ranks).count == 2, suits[0] == suits[1] {
+                return .fourToRoyalFlushTwoDeuces
+            }
+            // 4 to a SF: same suit, distinct ranks, both ≥ 6 (rank value), span ≤ 4.
+            if suits[0] == suits[1], Set(ranks).count == 2 {
+                let span = ranks[1] - ranks[0]
+                if span <= 4, ranks[0] >= 4 { // rank value ≥ 6 means rawValue ≥ 6 → index ≥ 4
+                    return .fourToStraightFlushTwoDeuces
+                }
+            }
+        }
+        return .twoDeuces
+    }
+
+    // MARK: 1 deuce
+
+    private static func classifyDW1Deuce(naturals: [PlayingCard], allHeld: [PlayingCard]) -> StrategyPattern {
+        // Pat hand (1 deuce + 4 naturals = 5 cards total).
+        if allHeld.count == 5 {
+            let result = HandResult.evaluate(cards: allHeld, wildcardRank: .two)
+            switch result {
+            case .fourDeuces, .wildRoyalFlush, .fiveOfAKind, .naturalRoyalFlush, .straightFlush,
+                 .fourOfAKind:
+                return .patHandOneDeuce
+            case .fullHouse:
+                return .patFullHouseOneDeuce
+            case .flush, .straight, .threeOfAKind:
+                return .patLowHandOneDeuce
+            default:
+                break
+            }
+        }
+
+        // Partial holds with 1 deuce.
+        // 4 to a royal: 1 deuce + 3 naturals all in {T–A} of same suit.
+        if naturals.count == 3 {
+            let ranks = naturals.map(\.rank.rawValue)
+            let suits = naturals.map(\.suit)
+            if ranks.allSatisfy({ $0 >= 10 }), Set(ranks).count == 3,
+               suits.dropFirst().allSatisfy({ $0 == suits[0] })
+            {
+                return .fourToRoyalFlushOneDeuce
+            }
+            // 4 to a SF: all same suit, distinct, 3 consecutive naturals ranked 5+.
+            if suits.dropFirst().allSatisfy({ $0 == suits[0] }), Set(ranks).count == 3 {
+                let sorted = ranks.sorted()
+                let span = sorted[2] - sorted[0]
+                if span == 2, sorted[0] >= 3 { // consecutive (no gaps), rank value ≥ 5
+                    return .fourToStraightFlushHighOneDeuce
+                }
+                // Other SF draws (span ≤ 4).
+                if span <= 4 {
+                    return .fourToStraightFlushOneDeuce
+                }
+            }
+        }
+
+        // 3 to a royal: 1 deuce + 2 naturals all in {T–A} of same suit.
+        if naturals.count == 2 {
+            let ranks = naturals.map(\.rank.rawValue)
+            let suits = naturals.map(\.suit)
+            if ranks.allSatisfy({ $0 >= 10 }), Set(ranks).count == 2, suits[0] == suits[1] {
+                return .threeToRoyalFlushOneDeuce
+            }
+            // 3 to a SF: same suit, distinct, 2 consecutive naturals ranked 6+.
+            if suits[0] == suits[1], Set(ranks).count == 2 {
+                let sorted = ranks.sorted()
+                let span = sorted[1] - sorted[0]
+                if span == 1, sorted[0] >= 4 { // consecutive, rank value ≥ 6
+                    return .threeToStraightFlushHighOneDeuce
+                }
+            }
+        }
+
+        return .oneDeuce
+    }
+
+    // MARK: 0 deuces
+
+    private static func classifyDW0Deuces(held: [PlayingCard]) -> StrategyPattern {
+        switch held.count {
+        case 0:
+            return .discardAll
+        case 1:
+            let rankValue = held[0].rank.rawValue
+            return rankValue >= 11 ? .oneHighCard : .discardAll
+        case 2:
+            return classifyDW0Two(held[0], held[1])
+        case 3:
+            return classifyDW0Three(held)
+        case 4:
+            return classifyDW0Four(held)
+        case 5:
+            return classifyDW0Five(held)
+        default:
+            preconditionFailure("holding set cannot have more than 5 elements")
+        }
+    }
+
+    private static func classifyDW0Five(_ cards: [PlayingCard]) -> StrategyPattern {
+        // In DW, pat hands are evaluated without wilds (k=0 path).
+        switch Hand(cards: cards).evaluate() {
+        case .royalFlush: .royalFlush
+        case .straightFlush: .straightFlush
+        case .fourOfAKind: .fourOfAKind
+        case .fullHouse: .fullHouse
+        case .flush: .flush
+        case .straight: .straight
+        case .threeOfAKind: .threeOfAKind
+        case .twoPair, .pair: .pair // two-pair treated as pair in DW
+        case .highCard: .discardAll
+        }
+    }
+
+    private static func classifyDW0Four(_ cards: [PlayingCard]) -> StrategyPattern {
+        let suits = cards.map(\.suit)
+        let ranks = cards.map(\.rank.rawValue)
+        let allSameSuit = Set(suits).count == 1
+
+        if allSameSuit {
+            if ranks.allSatisfy({ $0 >= 10 }) {
+                return .fourToRoyalFlush
+            }
+            if canFormStraightFlush(ranks) {
+                return .fourToStraightFlush
+            }
+            return .fourToFlush
+        }
+        let sorted = ranks.sorted()
+        guard Set(ranks).count == 4 else {
+            // Duplicate ranks = pair.
+            return .pair
+        }
+        if isOutsideStraightDraw(sorted) {
+            return .fourToOutsideStraight
+        }
+        if isInsideStraightDraw(sorted) {
+            return .fourToInsideStraight
+        }
+        return .discardAll
+    }
+
+    private static func classifyDW0Three(_ cards: [PlayingCard]) -> StrategyPattern {
+        let ranks = cards.map(\.rank.rawValue)
+        let suits = cards.map(\.suit)
+        if Set(ranks).count == 1 {
+            return .threeOfAKind
+        }
+        let allSameSuit = Set(suits).count == 1
+        if allSameSuit {
+            if ranks.allSatisfy({ $0 >= 10 }) {
+                return .threeToRoyalFlush
+            }
+            if canFormStraightFlush(ranks) {
+                return .threeToStraightFlushType1
+            }
+        }
+        let rankCounts = Dictionary(grouping: ranks, by: { $0 }).mapValues { $0.count }
+        if rankCounts.values.contains(2) {
+            return .pair
+        }
+        return .discardAll
+    }
+
+    private static func classifyDW0Two(_ first: PlayingCard, _ second: PlayingCard) -> StrategyPattern {
+        if first.rank == second.rank {
+            return .pair
+        }
+        let fv = first.rank.rawValue, sv = second.rank.rawValue
+        let sameSuit = first.suit == second.suit
+        // 2 to a royal flush, J/Q high (highest-rank 2-card hold in DW).
+        if sameSuit, fv >= 11, sv >= 11 {
+            return .twoToRoyalFlushJQHigh
+        }
+        return .discardAll
     }
 }

--- a/Sources/PlayingCard/StrategyPattern.swift
+++ b/Sources/PlayingCard/StrategyPattern.swift
@@ -527,7 +527,7 @@ public struct HoldClassifier {
             // 4 to a SF: same suit, distinct ranks, both ≥ 6 (rank value), span ≤ 4.
             if suits[0] == suits[1], Set(ranks).count == 2 {
                 let span = ranks[1] - ranks[0]
-                if span <= 4, ranks[0] >= 4 { // rank value ≥ 6 means rawValue ≥ 6 → index ≥ 4
+                if span <= 4, ranks[0] >= 6 {
                     return .fourToStraightFlushTwoDeuces
                 }
             }
@@ -568,7 +568,7 @@ public struct HoldClassifier {
             if suits.dropFirst().allSatisfy({ $0 == suits[0] }), Set(ranks).count == 3 {
                 let sorted = ranks.sorted()
                 let span = sorted[2] - sorted[0]
-                if span == 2, sorted[0] >= 3 { // consecutive (no gaps), rank value ≥ 5
+                if span == 2, sorted[0] >= 5 { // consecutive (no gaps), rank value ≥ 5
                     return .fourToStraightFlushHighOneDeuce
                 }
                 // Other SF draws (span ≤ 4).
@@ -589,7 +589,7 @@ public struct HoldClassifier {
             if suits[0] == suits[1], Set(ranks).count == 2 {
                 let sorted = ranks.sorted()
                 let span = sorted[1] - sorted[0]
-                if span == 1, sorted[0] >= 4 { // consecutive, rank value ≥ 6
+                if span == 1, sorted[0] >= 6 { // consecutive, rank value ≥ 6
                     return .threeToStraightFlushHighOneDeuce
                 }
             }

--- a/Tests/PlayingCardTests/DeucesWildTests.swift
+++ b/Tests/PlayingCardTests/DeucesWildTests.swift
@@ -257,7 +257,7 @@ final class DeucesWildTests: XCTestCase {
         XCTAssertEqual(table.payout(for: cards, bet: 5), 1000)
     }
 
-    func testDWThreeOfAKindNetPayout() {
+    func testDWFourOfAKindNetPayout() {
         let table = PayTable.deucesWild
         // J♠ J♥ J♦ 2♠ 5♣ → three jacks + wild deuce = four jacks (4K: 5x)
         // Wait: 3 natural jacks + 1 deuce → maxFreq=3 + k=1 = 4 ≥ 4 → four of a kind!

--- a/Tests/PlayingCardTests/DeucesWildTests.swift
+++ b/Tests/PlayingCardTests/DeucesWildTests.swift
@@ -1,0 +1,369 @@
+@testable import PlayingCard
+import XCTest
+
+/// Tests for Deuces Wild pay tables, hand evaluation, and optimal play.
+final class DeucesWildTests: XCTestCase {
+    // MARK: - Helpers
+
+    private func card(_ rank: Rank, _ suit: Suit) -> PlayingCard {
+        PlayingCard(rank: rank, suit: suit)
+    }
+
+    private func eval(_ cards: [PlayingCard]) -> HandResult {
+        HandResult.evaluate(cards: cards, wildcardRank: .two)
+    }
+
+    // MARK: - New Jacks or Better pay table multipliers
+
+    func testJacksOrBetter95Payouts() {
+        let table = PayTable.jacksOrBetter95
+        XCTAssertEqual(table.multiplier(for: .royalFlush), 800)
+        XCTAssertEqual(table.multiplier(for: .straightFlush), 50)
+        XCTAssertEqual(table.multiplier(for: .fourOfAKind), 25)
+        XCTAssertEqual(table.multiplier(for: .fullHouse), 9)
+        XCTAssertEqual(table.multiplier(for: .flush), 5) // 5, not 6
+        XCTAssertEqual(table.multiplier(for: .straight), 4)
+        XCTAssertEqual(table.multiplier(for: .threeOfAKind), 3)
+        XCTAssertEqual(table.multiplier(for: .twoPair), 2)
+        XCTAssertEqual(table.multiplier(for: .jacksOrBetter), 1)
+        XCTAssertEqual(table.multiplier(for: .noWin), 0)
+    }
+
+    func testJacksOrBetter86Payouts() {
+        let table = PayTable.jacksOrBetter86
+        XCTAssertEqual(table.multiplier(for: .royalFlush), 800)
+        XCTAssertEqual(table.multiplier(for: .straightFlush), 50)
+        XCTAssertEqual(table.multiplier(for: .fourOfAKind), 25)
+        XCTAssertEqual(table.multiplier(for: .fullHouse), 8) // 8, not 9
+        XCTAssertEqual(table.multiplier(for: .flush), 6)
+        XCTAssertEqual(table.multiplier(for: .straight), 4)
+        XCTAssertEqual(table.multiplier(for: .threeOfAKind), 3)
+        XCTAssertEqual(table.multiplier(for: .twoPair), 2)
+        XCTAssertEqual(table.multiplier(for: .jacksOrBetter), 1)
+        XCTAssertEqual(table.multiplier(for: .noWin), 0)
+    }
+
+    func testJacksOrBetter95Name() {
+        XCTAssertEqual(PayTable.jacksOrBetter95.name, "Jacks or Better (9/5)")
+    }
+
+    func testJacksOrBetter86Name() {
+        XCTAssertEqual(PayTable.jacksOrBetter86.name, "Jacks or Better (8/6)")
+    }
+
+    // MARK: - Deuces Wild pay table
+
+    func testDeucesWildPayouts() {
+        let table = PayTable.deucesWild
+        XCTAssertEqual(table.multiplier(for: .naturalRoyalFlush), 800)
+        XCTAssertEqual(table.multiplier(for: .fourDeuces), 200)
+        XCTAssertEqual(table.multiplier(for: .wildRoyalFlush), 25)
+        XCTAssertEqual(table.multiplier(for: .fiveOfAKind), 15)
+        XCTAssertEqual(table.multiplier(for: .straightFlush), 9)
+        XCTAssertEqual(table.multiplier(for: .fourOfAKind), 5)
+        XCTAssertEqual(table.multiplier(for: .fullHouse), 3)
+        XCTAssertEqual(table.multiplier(for: .flush), 2)
+        XCTAssertEqual(table.multiplier(for: .straight), 2)
+        XCTAssertEqual(table.multiplier(for: .threeOfAKind), 1)
+        XCTAssertEqual(table.multiplier(for: .noWin), 0)
+    }
+
+    func testDeucesWildWildcardRank() {
+        XCTAssertEqual(PayTable.deucesWild.wildcardRank, .two)
+    }
+
+    func testDeucesWildName() {
+        XCTAssertEqual(PayTable.deucesWild.name, "Deuces Wild (Full Pay)")
+    }
+
+    // MARK: - HandResult.evaluate with wildcardRank
+
+    func testNaturalRoyalFlush() {
+        let cards = [
+            card(.ace, .spades), card(.king, .spades), card(.queen, .spades),
+            card(.jack, .spades), card(.ten, .spades),
+        ]
+        XCTAssertEqual(eval(cards), .naturalRoyalFlush)
+    }
+
+    func testNaturalRoyalFlushIsHigherThanRoyalFlush() {
+        XCTAssertGreaterThan(HandResult.naturalRoyalFlush, HandResult.royalFlush)
+    }
+
+    func testFourDeuces() {
+        let cards = [
+            card(.two, .spades), card(.two, .hearts), card(.two, .diamonds),
+            card(.two, .clubs), card(.ace, .spades),
+        ]
+        XCTAssertEqual(eval(cards), .fourDeuces)
+    }
+
+    func testWildRoyalFlush() {
+        // A♠ K♠ Q♠ J♠ 2♥ — deuce acts as T♠, completing the royal flush.
+        let cards = [
+            card(.ace, .spades), card(.king, .spades), card(.queen, .spades),
+            card(.jack, .spades), card(.two, .hearts),
+        ]
+        XCTAssertEqual(eval(cards), .wildRoyalFlush)
+    }
+
+    func testWildRoyalFlushTwoDeuces() {
+        // A♠ K♠ Q♠ 2♥ 2♦ — two deuces act as J♠ and T♠.
+        let cards = [
+            card(.ace, .spades), card(.king, .spades), card(.queen, .spades),
+            card(.two, .hearts), card(.two, .diamonds),
+        ]
+        XCTAssertEqual(eval(cards), .wildRoyalFlush)
+    }
+
+    func testFiveOfAKind() {
+        // Four aces + one deuce → five aces.
+        let cards = [
+            card(.ace, .spades), card(.ace, .hearts), card(.ace, .diamonds),
+            card(.ace, .clubs), card(.two, .spades),
+        ]
+        XCTAssertEqual(eval(cards), .fiveOfAKind)
+    }
+
+    func testFiveOfAKindThreeDeuces() {
+        // K♠ K♥ 2♠ 2♥ 2♦ → two deuces fill king slots → five kings.
+        let cards = [
+            card(.king, .spades), card(.king, .hearts),
+            card(.two, .spades), card(.two, .hearts), card(.two, .diamonds),
+        ]
+        XCTAssertEqual(eval(cards), .fiveOfAKind)
+    }
+
+    func testWildStraightFlush() {
+        // 7♠ 8♠ 9♠ T♠ 2♥ — deuce acts as 6♠ or J♠ → straight flush.
+        let cards = [
+            card(.seven, .spades), card(.eight, .spades), card(.nine, .spades),
+            card(.ten, .spades), card(.two, .hearts),
+        ]
+        XCTAssertEqual(eval(cards), .straightFlush)
+    }
+
+    func testWildFourOfAKind() {
+        // K♠ K♥ K♦ 2♠ 7♣ — deuce acts as K♣ → four kings.
+        let cards = [
+            card(.king, .spades), card(.king, .hearts), card(.king, .diamonds),
+            card(.two, .spades), card(.seven, .clubs),
+        ]
+        XCTAssertEqual(eval(cards), .fourOfAKind)
+    }
+
+    func testWildFullHouse() {
+        // Q♠ Q♥ 7♦ 7♣ 2♠ — deuce completes trips → Q-Q-Q-7-7.
+        let cards = [
+            card(.queen, .spades), card(.queen, .hearts),
+            card(.seven, .diamonds), card(.seven, .clubs),
+            card(.two, .spades),
+        ]
+        XCTAssertEqual(eval(cards), .fullHouse)
+    }
+
+    func testWildFlush() {
+        // 3♠ 7♠ 9♠ K♠ 2♥ — deuce can be any ♠ → flush.
+        let cards = [
+            card(.three, .spades), card(.seven, .spades), card(.nine, .spades),
+            card(.king, .spades), card(.two, .hearts),
+        ]
+        XCTAssertEqual(eval(cards), .flush)
+    }
+
+    func testWildStraight() {
+        // 4♠ 5♥ 7♦ 8♣ 2♠ — deuce acts as 6 → 4-5-6-7-8 straight.
+        let cards = [
+            card(.four, .spades), card(.five, .hearts), card(.seven, .diamonds),
+            card(.eight, .clubs), card(.two, .spades),
+        ]
+        XCTAssertEqual(eval(cards), .straight)
+    }
+
+    func testWildThreeOfAKind() {
+        // J♠ J♥ 4♦ 8♣ 2♠ — deuce acts as J → three jacks.
+        let cards = [
+            card(.jack, .spades), card(.jack, .hearts),
+            card(.four, .diamonds), card(.eight, .clubs),
+            card(.two, .spades),
+        ]
+        XCTAssertEqual(eval(cards), .threeOfAKind)
+    }
+
+    func testPairIsNoWinInDW() {
+        // A pair without a deuce doesn't pay in Deuces Wild.
+        let cards = [
+            card(.king, .spades), card(.king, .hearts),
+            card(.three, .diamonds), card(.seven, .clubs),
+            card(.nine, .spades),
+        ]
+        XCTAssertEqual(eval(cards), .noWin)
+    }
+
+    func testTwoPairIsNoWinInDW() {
+        let cards = [
+            card(.king, .spades), card(.king, .hearts),
+            card(.ace, .diamonds), card(.ace, .clubs),
+            card(.seven, .spades),
+        ]
+        XCTAssertEqual(eval(cards), .noWin)
+    }
+
+    func testHighCardIsNoWinInDW() {
+        let cards = [
+            card(.ace, .spades), card(.king, .hearts),
+            card(.queen, .diamonds), card(.nine, .clubs),
+            card(.four, .spades),
+        ]
+        XCTAssertEqual(eval(cards), .noWin)
+    }
+
+    func testWheelStraightFlushInDW() {
+        // A♠ 3♠ 4♠ 5♠ 2♥ — deuce acts as 2♠ → A-2-3-4-5♠ wheel SF.
+        let cards = [
+            card(.ace, .spades), card(.three, .spades), card(.four, .spades),
+            card(.five, .spades), card(.two, .hearts),
+        ]
+        XCTAssertEqual(eval(cards), .straightFlush)
+    }
+
+    // MARK: - PayTable.deucesWild payout
+
+    func testDWNaturalRoyalFlushPayoutMaxBet() {
+        let table = PayTable.deucesWild
+        let cards = [
+            card(.ace, .spades), card(.king, .spades), card(.queen, .spades),
+            card(.jack, .spades), card(.ten, .spades),
+        ]
+        XCTAssertEqual(table.payout(for: cards, bet: 5), 4000)
+    }
+
+    func testDWNaturalRoyalFlushPayoutSubMaxBet() {
+        let table = PayTable.deucesWild
+        let cards = [
+            card(.ace, .spades), card(.king, .spades), card(.queen, .spades),
+            card(.jack, .spades), card(.ten, .spades),
+        ]
+        XCTAssertEqual(table.payout(for: cards, bet: 1), 250)
+    }
+
+    func testDWFourDeucesPayout() {
+        let table = PayTable.deucesWild
+        let cards = [
+            card(.two, .spades), card(.two, .hearts), card(.two, .diamonds),
+            card(.two, .clubs), card(.ace, .spades),
+        ]
+        // 200 × 5 coins
+        XCTAssertEqual(table.payout(for: cards, bet: 5), 1000)
+    }
+
+    func testDWThreeOfAKindNetPayout() {
+        let table = PayTable.deucesWild
+        // J♠ J♥ J♦ 2♠ 5♣ → three jacks + wild deuce = four jacks (4K: 5x)
+        // Wait: 3 natural jacks + 1 deuce → maxFreq=3 + k=1 = 4 ≥ 4 → four of a kind!
+        let cards = [
+            card(.jack, .spades), card(.jack, .hearts), card(.jack, .diamonds),
+            card(.two, .spades), card(.five, .clubs),
+        ]
+        XCTAssertEqual(table.handResult(for: cards), .fourOfAKind)
+        // 5 × 5 - 5 = +20
+        XCTAssertEqual(table.netPayout(for: cards, bet: 5), 20)
+    }
+
+    // MARK: - HandResult ordering
+
+    func testNewHandResultOrdering() {
+        XCTAssertLessThan(HandResult.royalFlush, HandResult.fiveOfAKind)
+        XCTAssertLessThan(HandResult.fiveOfAKind, HandResult.wildRoyalFlush)
+        XCTAssertLessThan(HandResult.wildRoyalFlush, HandResult.fourDeuces)
+        XCTAssertLessThan(HandResult.fourDeuces, HandResult.naturalRoyalFlush)
+    }
+
+    func testNewHandResultDescriptions() {
+        XCTAssertEqual(HandResult.fiveOfAKind.description, "Five of a Kind")
+        XCTAssertEqual(HandResult.wildRoyalFlush.description, "Wild Royal Flush")
+        XCTAssertEqual(HandResult.fourDeuces.description, "Four Deuces")
+        XCTAssertEqual(HandResult.naturalRoyalFlush.description, "Natural Royal Flush")
+    }
+
+    func testNewHandResultIsWin() {
+        XCTAssertTrue(HandResult.fiveOfAKind.isWin)
+        XCTAssertTrue(HandResult.wildRoyalFlush.isWin)
+        XCTAssertTrue(HandResult.fourDeuces.isWin)
+        XCTAssertTrue(HandResult.naturalRoyalFlush.isWin)
+    }
+
+    // MARK: - OptimalPlay with Deuces Wild
+
+    func testDWOptimalHoldFourDeuces() async {
+        // Four deuces + any kicker: always hold all.
+        let engine = OptimalPlay(payTable: .deucesWild)
+        let hand = [
+            card(.two, .spades), card(.two, .hearts), card(.two, .diamonds),
+            card(.two, .clubs), card(.ace, .spades),
+        ]
+        let result = await engine.evaluate(hand: hand)
+        XCTAssertEqual(result.optimalHeld, [0, 1, 2, 3, 4])
+        XCTAssertEqual(result.optimalEV, 200.0, accuracy: 0.001)
+    }
+
+    func testDWOptimalHoldNaturalRoyalFlushHoldsAll() async {
+        let engine = OptimalPlay(payTable: .deucesWild)
+        let hand = [
+            card(.ace, .clubs), card(.king, .clubs), card(.queen, .clubs),
+            card(.jack, .clubs), card(.ten, .clubs),
+        ]
+        let result = await engine.evaluate(hand: hand)
+        XCTAssertEqual(result.optimalHeld, [0, 1, 2, 3, 4])
+        XCTAssertEqual(result.optimalEV, 800.0, accuracy: 0.001)
+    }
+
+    func testDWOptimalHoldPatWildRoyalFlush() async {
+        // A♠ K♠ Q♠ J♠ 2♥ → already a wild royal flush (25x). Hold all.
+        let engine = OptimalPlay(payTable: .deucesWild)
+        let hand = [
+            card(.ace, .spades), card(.king, .spades), card(.queen, .spades),
+            card(.jack, .spades), card(.two, .hearts),
+        ]
+        let result = await engine.evaluate(hand: hand)
+        XCTAssertEqual(result.optimalHeld, [0, 1, 2, 3, 4])
+        XCTAssertEqual(result.optimalEV, 25.0, accuracy: 0.001)
+    }
+
+    func testDWOptimalHoldThreeDeuces() async {
+        // Three deuces + two non-royal naturals: hold the deuces.
+        let engine = OptimalPlay(payTable: .deucesWild)
+        let hand = [
+            card(.two, .spades), card(.two, .hearts), card(.two, .diamonds),
+            card(.three, .clubs), card(.seven, .spades),
+        ]
+        let result = await engine.evaluate(hand: hand)
+        XCTAssertEqual(result.optimalHeld, [0, 1, 2])
+    }
+
+    func testDWOptimalEVNonNegative() async {
+        let engine = OptimalPlay(payTable: .deucesWild)
+        let hand = [
+            card(.three, .spades), card(.six, .hearts), card(.eight, .clubs),
+            card(.queen, .diamonds), card(.king, .spades),
+        ]
+        let result = await engine.evaluate(hand: hand)
+        XCTAssertGreaterThanOrEqual(result.optimalEV, 0)
+    }
+
+    func testJoB95OptimalPlayUsesCorrectFlushMultiplier() async {
+        // Flush pays 5 in 9/5 instead of 6 in 9/6. Verify engine uses the right table.
+        let engine95 = OptimalPlay(payTable: .jacksOrBetter95)
+        let engine96 = OptimalPlay(payTable: .jacksOrBetter96)
+        // Pat flush.
+        let hand = [
+            card(.ace, .clubs), card(.jack, .clubs), card(.eight, .clubs),
+            card(.five, .clubs), card(.two, .clubs),
+        ]
+        let result95 = await engine95.evaluate(hand: hand)
+        let result96 = await engine96.evaluate(hand: hand)
+        // 9/6 flush = 6x, 9/5 flush = 5x.
+        XCTAssertEqual(result96.optimalEV, 6.0, accuracy: 0.001)
+        XCTAssertEqual(result95.optimalEV, 5.0, accuracy: 0.001)
+    }
+}

--- a/Tests/PlayingCardTests/DeucesWildTests.swift
+++ b/Tests/PlayingCardTests/DeucesWildTests.swift
@@ -366,4 +366,66 @@ final class DeucesWildTests: XCTestCase {
         XCTAssertEqual(result96.optimalEV, 6.0, accuracy: 0.001)
         XCTAssertEqual(result95.optimalEV, 5.0, accuracy: 0.001)
     }
+
+    // MARK: - Strategy pattern threshold correctness
+
+    func testDW2DeuceSFThresholdBelowSix() {
+        // 2♣ 2♦ 4♣ 5♣ + K♦: both naturals below rank 6 → should NOT be fourToStraightFlushTwoDeuces.
+        let hand = [
+            card(.two, .clubs), card(.two, .diamonds),
+            card(.four, .clubs), card(.five, .clubs), card(.king, .diamonds),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3])
+        XCTAssertEqual(pattern, .twoDeuces)
+    }
+
+    func testDW2DeuceSFThresholdAtSix() {
+        // 2♣ 2♦ 6♣ 9♣ + K♦: both naturals ≥ 6, span 3, same suit → fourToStraightFlushTwoDeuces.
+        let hand = [
+            card(.two, .clubs), card(.two, .diamonds),
+            card(.six, .clubs), card(.nine, .clubs), card(.king, .diamonds),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3])
+        XCTAssertEqual(pattern, .fourToStraightFlushTwoDeuces)
+    }
+
+    func testDW1DeuceSFHighThresholdBelowFive() {
+        // 2♠ 3♣ 4♣ 5♣ + K♦: consecutive naturals 3-4-5, lowest < 5 → fourToStraightFlushOneDeuce (not high).
+        let hand = [
+            card(.two, .spades), card(.three, .clubs), card(.four, .clubs),
+            card(.five, .clubs), card(.king, .diamonds),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3])
+        XCTAssertEqual(pattern, .fourToStraightFlushOneDeuce)
+    }
+
+    func testDW1DeuceSFHighThresholdAtFive() {
+        // 2♠ 5♣ 6♣ 7♣ + K♦: consecutive naturals 5-6-7, lowest = 5 → fourToStraightFlushHighOneDeuce.
+        let hand = [
+            card(.two, .spades), card(.five, .clubs), card(.six, .clubs),
+            card(.seven, .clubs), card(.king, .diamonds),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3])
+        XCTAssertEqual(pattern, .fourToStraightFlushHighOneDeuce)
+    }
+
+    func testDW1Deuce3SFHighThresholdBelowSix() {
+        // 2♠ 4♥ 5♥ + K♦ Q♠: consecutive naturals 4-5, lowest < 6 → oneDeuce.
+        let hand = [
+            card(.two, .spades), card(.four, .hearts), card(.five, .hearts),
+            card(.king, .diamonds), card(.queen, .spades),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2])
+        XCTAssertEqual(pattern, .oneDeuce)
+    }
+
+    func testDW1Deuce3SFHighThresholdAtSix() {
+        // 2♠ 6♥ 7♥ + K♦ Q♠: consecutive naturals 6-7, lowest = 6 → threeToStraightFlushHighOneDeuce.
+        let hand = [
+            card(.two, .spades), card(.six, .hearts), card(.seven, .hearts),
+            card(.king, .diamonds), card(.queen, .spades),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2])
+        XCTAssertEqual(pattern, .threeToStraightFlushHighOneDeuce)
+    }
 }


### PR DESCRIPTION
## Summary

Adds three new pay tables and full Deuces Wild wildcard support.

## New Pay Tables

| Pay Table | Description | Return |
|-----------|-------------|--------|
| `PayTable.jacksOrBetter95` | 9/5 Jacks or Better (flush pays 5) | 98.45% |
| `PayTable.jacksOrBetter86` | 8/6 Jacks or Better (full house pays 8) | 98.39% |
| `PayTable.deucesWild` | Full-Pay Deuces Wild (all 2s wild) | 100.76% |

The existing `jacksOrBetter96` (9/6) was already correctly named.

## Wildcard Support

- Added `wildcardRank: Rank?` to `PayTable` (default `nil`, backward compatible)
- Added `HandResult.evaluate(cards:wildcardRank:)` for wildcard hand evaluation
- New `HandResult` cases: `naturalRoyalFlush`, `fourDeuces`, `wildRoyalFlush`, `fiveOfAKind`
- Pairs and two-pair do not pay in Deuces Wild (minimum winning hand: three of a kind)
- `OptimalPlay` only supports `wildcardRank == .two`; the fast evaluator hard-codes rank-index 0 for wild detection and traps on any other wildcard rank

## Optimal Play

- `OptimalPlay` auto-detects wildcard games via `payTable.wildcardRank`
- Added `fastEVWild` and `handResultCodeDeuces` hot-path evaluator for Deuces Wild
- All hold strategy patterns updated: 18 new `StrategyPattern` cases for DW
- `HoldClassifier.classifyDeucesWild` public method added

## Tests

43 new tests in `DeucesWildTests.swift` covering all new hand types, pay table multipliers, optimal play decisions, and strategy pattern threshold boundary conditions. 157 total tests, all passing.

## References

- [9/5 JoB strategy](https://wizardofodds.com/games/video-poker/strategy/jacks-or-better/9-5/)
- [8/6 JoB strategy](https://wizardofodds.com/games/video-poker/strategy/jacks-or-better/8-6/)
- [Full-Pay Deuces Wild strategy](https://wizardofodds.com/games/video-poker/strategy/deuces-wild/full-pay/simple/)