### PR TITLE
Add Hand.evaluate(wildcardRank:) for wildcard-aware HandType evaluation

### DIFF
--- a/Sources/PlayingCard/Hand.swift
+++ b/Sources/PlayingCard/Hand.swift
@@ -110,30 +110,23 @@ public struct Hand {
     /// Evaluates the best hand type, treating cards of `wildcardRank` as wild.
     ///
     /// When `wildcardRank` is nil this is equivalent to `evaluate()`. When wildcards
-    /// are present, winning types derive from `HandResult` (wildcard-aware); for
-    /// non-paying combinations the standard evaluator is used, with `.highCard`
-    /// upgraded to `.pair` when at least one wild card is held.
+    /// are present, the result derives from `HandResult` (wildcard-aware) via its
+    /// `handType` property; for non-paying combinations the standard evaluator is used,
+    /// with `.highCard` upgraded to `.pair` when at least one wild card is held.
     public func evaluate(wildcardRank: Rank?) -> HandType {
         guard let wildcardRank else { return evaluate() }
         guard cards.count == 5 else { return .highCard }
 
-        switch HandResult.evaluate(cards: cards, wildcardRank: wildcardRank) {
-        case .naturalRoyalFlush, .wildRoyalFlush, .royalFlush: return .royalFlush
-        case .straightFlush: return .straightFlush
-        case .fiveOfAKind, .fourDeuces, .fourOfAKind: return .fourOfAKind
-        case .fullHouse: return .fullHouse
-        case .flush: return .flush
-        case .straight: return .straight
-        case .threeOfAKind: return .threeOfAKind
-        case .twoPair: return .twoPair
-        case .jacksOrBetter: return .pair
-        case .noWin:
-            let base = evaluate()
-            if base == .highCard, cards.contains(where: { $0.rank == wildcardRank }) {
-                return .pair
-            }
-            return base
+        let result = HandResult.evaluate(cards: cards, wildcardRank: wildcardRank)
+        if let handType = result.handType {
+            return handType
         }
+        // .noWin: use standard evaluation, upgrading highCard when a wild is present.
+        let base = evaluate()
+        if base == .highCard, cards.contains(where: { $0.rank == wildcardRank }) {
+            return .pair
+        }
+        return base
     }
 
     private func findBestFiveCardHand() -> HandType {

--- a/Sources/PlayingCard/Hand.swift
+++ b/Sources/PlayingCard/Hand.swift
@@ -103,33 +103,50 @@ public struct Hand {
         if cards.count == 5 {
             return evaluateFiveCards(cards)
         } else {
-            return findBestFiveCardHand()
+            return findBestFiveCardHand(evaluator: evaluateFiveCards)
         }
     }
 
     /// Evaluates the best hand type, treating cards of `wildcardRank` as wild.
     ///
-    /// When `wildcardRank` is nil this is equivalent to `evaluate()`. When wildcards
-    /// are present, the result derives from `HandResult` (wildcard-aware) via its
-    /// `handType` property; for non-paying combinations the standard evaluator is used,
-    /// with `.highCard` upgraded to `.pair` when at least one wild card is held.
+    /// When `wildcardRank` is nil this is equivalent to `evaluate()`. Works with 5+ cards,
+    /// finding the best possible hand, matching `evaluate()`. When wildcards are present,
+    /// each candidate 5-card combination is evaluated via `HandResult` (wildcard-aware) using
+    /// its `handType` property; for non-paying combinations the standard evaluator is used,
+    /// with `.highCard` upgraded to `.pair` when that combination holds at least one wild card.
     public func evaluate(wildcardRank: Rank?) -> HandType {
         guard let wildcardRank else { return evaluate() }
-        guard cards.count == 5 else { return .highCard }
+        guard cards.count >= 5 else { return .highCard }
 
-        let result = HandResult.evaluate(cards: cards, wildcardRank: wildcardRank)
-        if let handType = result.handType {
-            return handType
+        func evaluateFiveCardsWithWild(
+            _ c0: PlayingCard,
+            _ c1: PlayingCard,
+            _ c2: PlayingCard,
+            _ c3: PlayingCard,
+            _ c4: PlayingCard,
+        ) -> HandType {
+            let fiveCards = [c0, c1, c2, c3, c4]
+            let result = HandResult.evaluate(cards: fiveCards, wildcardRank: wildcardRank)
+            if let handType = result.handType {
+                return handType
+            }
+            // .noWin: use standard evaluation, upgrading highCard when a wild is present.
+            let base = evaluateFiveCards(c0, c1, c2, c3, c4)
+            if base == .highCard, fiveCards.contains(where: { $0.rank == wildcardRank }) {
+                return .pair
+            }
+            return base
         }
-        // .noWin: use standard evaluation, upgrading highCard when a wild is present.
-        let base = evaluate()
-        if base == .highCard, cards.contains(where: { $0.rank == wildcardRank }) {
-            return .pair
+
+        if cards.count == 5 {
+            return evaluateFiveCardsWithWild(cards[0], cards[1], cards[2], cards[3], cards[4])
         }
-        return base
+        return findBestFiveCardHand(evaluator: evaluateFiveCardsWithWild)
     }
 
-    private func findBestFiveCardHand() -> HandType {
+    private func findBestFiveCardHand(
+        evaluator: (PlayingCard, PlayingCard, PlayingCard, PlayingCard, PlayingCard) -> HandType,
+    ) -> HandType {
         let count = cards.count
         guard count >= 5 else { return .highCard }
 
@@ -144,7 +161,7 @@ public struct Hand {
                     for i3 in i2 + 1 ..< count - 1 {
                         let c3 = cards[i3]
                         for i4 in i3 + 1 ..< count {
-                            let handType = evaluateFiveCards(c0, c1, c2, c3, cards[i4])
+                            let handType = evaluator(c0, c1, c2, c3, cards[i4])
                             if handType > bestHandType {
                                 bestHandType = handType
                                 if bestHandType == .royalFlush {

--- a/Sources/PlayingCard/Hand.swift
+++ b/Sources/PlayingCard/Hand.swift
@@ -107,6 +107,35 @@ public struct Hand {
         }
     }
 
+    /// Evaluates the best hand type, treating cards of `wildcardRank` as wild.
+    ///
+    /// When `wildcardRank` is nil this is equivalent to `evaluate()`. When wildcards
+    /// are present, winning types derive from `HandResult` (wildcard-aware); for
+    /// non-paying combinations the standard evaluator is used, with `.highCard`
+    /// upgraded to `.pair` when at least one wild card is held.
+    public func evaluate(wildcardRank: Rank?) -> HandType {
+        guard let wildcardRank else { return evaluate() }
+        guard cards.count == 5 else { return .highCard }
+
+        switch HandResult.evaluate(cards: cards, wildcardRank: wildcardRank) {
+        case .naturalRoyalFlush, .wildRoyalFlush, .royalFlush: return .royalFlush
+        case .straightFlush: return .straightFlush
+        case .fiveOfAKind, .fourDeuces, .fourOfAKind: return .fourOfAKind
+        case .fullHouse: return .fullHouse
+        case .flush: return .flush
+        case .straight: return .straight
+        case .threeOfAKind: return .threeOfAKind
+        case .twoPair: return .twoPair
+        case .jacksOrBetter: return .pair
+        case .noWin:
+            let base = evaluate()
+            if base == .highCard, cards.contains(where: { $0.rank == wildcardRank }) {
+                return .pair
+            }
+            return base
+        }
+    }
+
     private func findBestFiveCardHand() -> HandType {
         let count = cards.count
         guard count >= 5 else { return .highCard }

--- a/Sources/PlayingCard/PayTable.swift
+++ b/Sources/PlayingCard/PayTable.swift
@@ -65,7 +65,26 @@ public enum HandResult: Int, CaseIterable, Comparable, CustomStringConvertible {
         self != .noWin
     }
 
-    /// Classifies a 5-card hand into its video poker result.
+    /// The generic poker hand type corresponding to this video poker result.
+    ///
+    /// Returns nil for `.noWin` because the underlying hand type (pair, two-pair, high card)
+    /// cannot be determined from the pay table result alone.
+    public var handType: HandType? {
+        switch self {
+        case .noWin: nil
+        case .jacksOrBetter: .pair
+        case .twoPair: .twoPair
+        case .threeOfAKind: .threeOfAKind
+        case .straight: .straight
+        case .flush: .flush
+        case .fullHouse: .fullHouse
+        case .fourOfAKind, .fourDeuces: .fourOfAKind
+        case .straightFlush: .straightFlush
+        case .royalFlush, .wildRoyalFlush, .naturalRoyalFlush: .royalFlush
+        case .fiveOfAKind: .fourOfAKind
+        }
+    }
+
     ///
     /// - Parameters:
     ///   - cards: Exactly 5 cards.

--- a/Sources/PlayingCard/PayTable.swift
+++ b/Sources/PlayingCard/PayTable.swift
@@ -69,6 +69,12 @@ public enum HandResult: Int, CaseIterable, Comparable, CustomStringConvertible {
     ///
     /// Returns nil for `.noWin` because the underlying hand type (pair, two-pair, high card)
     /// cannot be determined from the pay table result alone.
+    ///
+    /// This mapping is lossy for wild-only results that have no equivalent `HandType` case:
+    /// `.fiveOfAKind` and `.fourDeuces` both map to `.fourOfAKind`, and `.wildRoyalFlush` /
+    /// `.naturalRoyalFlush` both map to `.royalFlush`. Callers that need to distinguish these
+    /// wild-enhanced hands from their standard counterparts should switch on `HandResult`
+    /// directly instead of relying on `handType`.
     public var handType: HandType? {
         switch self {
         case .noWin: nil

--- a/Tests/PlayingCardTests/DeucesWildTests.swift
+++ b/Tests/PlayingCardTests/DeucesWildTests.swift
@@ -293,6 +293,16 @@ final class DeucesWildTests: XCTestCase {
         XCTAssertTrue(HandResult.naturalRoyalFlush.isWin)
     }
 
+    /// `HandType` has no five-of-a-kind or "four deuces" case, so the mapping from
+    /// wild-only `HandResult` cases to `HandType` is intentionally lossy. This test
+    /// pins down the exact (documented) approximation so any future change to it is explicit.
+    func testHandResultHandTypeLossyWildMapping() {
+        XCTAssertEqual(HandResult.fiveOfAKind.handType, .fourOfAKind)
+        XCTAssertEqual(HandResult.fourDeuces.handType, .fourOfAKind)
+        XCTAssertEqual(HandResult.wildRoyalFlush.handType, .royalFlush)
+        XCTAssertEqual(HandResult.naturalRoyalFlush.handType, .royalFlush)
+    }
+
     // MARK: - OptimalPlay with Deuces Wild
 
     func testDWOptimalHoldFourDeuces() async {

--- a/Tests/PlayingCardTests/HandTests.swift
+++ b/Tests/PlayingCardTests/HandTests.swift
@@ -306,4 +306,53 @@ final class HandTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Wildcard-aware evaluate
+
+    func testEvaluateWildcardNilMatchesStandard() {
+        let hand = Hand(cards: [
+            PlayingCard(rank: .nine, suit: .diamonds),
+            PlayingCard(rank: .two, suit: .diamonds),
+            PlayingCard(rank: .five, suit: .diamonds),
+            PlayingCard(rank: .four, suit: .spades),
+            PlayingCard(rank: .eight, suit: .clubs),
+        ])
+        XCTAssertEqual(hand.evaluate(wildcardRank: nil), hand.evaluate())
+    }
+
+    func testEvaluateWildcardUpgradesHighCardToPair() {
+        // 9,2,5,4,8: no natural pair; 2 is wild → at least a pair.
+        let hand = Hand(cards: [
+            PlayingCard(rank: .nine, suit: .diamonds),
+            PlayingCard(rank: .two, suit: .diamonds),
+            PlayingCard(rank: .five, suit: .diamonds),
+            PlayingCard(rank: .four, suit: .spades),
+            PlayingCard(rank: .eight, suit: .clubs),
+        ])
+        XCTAssertEqual(hand.evaluate(wildcardRank: .two), .pair)
+    }
+
+    func testEvaluateWildcardNaturalPairBecomesThreeOfAKind() {
+        // 9,2,9,4,8: natural pair of 9s + wild → three of a kind.
+        let hand = Hand(cards: [
+            PlayingCard(rank: .nine, suit: .diamonds),
+            PlayingCard(rank: .two, suit: .diamonds),
+            PlayingCard(rank: .nine, suit: .hearts),
+            PlayingCard(rank: .four, suit: .spades),
+            PlayingCard(rank: .eight, suit: .clubs),
+        ])
+        XCTAssertEqual(hand.evaluate(wildcardRank: .two), .threeOfAKind)
+    }
+
+    func testEvaluateWildcardNoWildActsLikeStandard() {
+        // Pair of aces, no wild cards in hand.
+        let hand = Hand(cards: [
+            PlayingCard(rank: .ace, suit: .spades),
+            PlayingCard(rank: .ace, suit: .hearts),
+            PlayingCard(rank: .three, suit: .diamonds),
+            PlayingCard(rank: .five, suit: .clubs),
+            PlayingCard(rank: .seven, suit: .spades),
+        ])
+        XCTAssertEqual(hand.evaluate(wildcardRank: .two), hand.evaluate())
+    }
 }

--- a/Tests/PlayingCardTests/HandTests.swift
+++ b/Tests/PlayingCardTests/HandTests.swift
@@ -355,4 +355,37 @@ final class HandTests: XCTestCase {
         ])
         XCTAssertEqual(hand.evaluate(wildcardRank: .two), hand.evaluate())
     }
+
+    func testEvaluateWildcardSupportsSevenCards() {
+        // 7 cards: 9,9,2(wild),4,8,3,6. The best 5-card subset (9,9,2,4,8) is three of
+        // a kind via the wild 9. No 5-card subset of these 7 cards forms a flush, straight,
+        // full house, or four of a kind, so three of a kind is the overall best. The standard
+        // (non-wildcard) evaluation of the full 7 cards is only a pair, so this also confirms
+        // the wildcard-aware search is actually considering the winning subset.
+        let hand = Hand(cards: [
+            PlayingCard(rank: .nine, suit: .diamonds),
+            PlayingCard(rank: .nine, suit: .hearts),
+            PlayingCard(rank: .two, suit: .clubs),
+            PlayingCard(rank: .four, suit: .spades),
+            PlayingCard(rank: .eight, suit: .clubs),
+            PlayingCard(rank: .three, suit: .spades),
+            PlayingCard(rank: .six, suit: .diamonds),
+        ])
+        XCTAssertEqual(hand.evaluate(), .pair)
+        XCTAssertEqual(hand.evaluate(wildcardRank: .two), .threeOfAKind)
+    }
+
+    func testEvaluateWildcardSupportsSixCards() {
+        // Drop one filler card from the 7-card case above; the winning 5-card subset
+        // (9,9,2,4,8) is unaffected, so the wildcard-aware result stays three of a kind.
+        let hand = Hand(cards: [
+            PlayingCard(rank: .nine, suit: .diamonds),
+            PlayingCard(rank: .nine, suit: .hearts),
+            PlayingCard(rank: .two, suit: .clubs),
+            PlayingCard(rank: .four, suit: .spades),
+            PlayingCard(rank: .eight, suit: .clubs),
+            PlayingCard(rank: .three, suit: .spades),
+        ])
+        XCTAssertEqual(hand.evaluate(wildcardRank: .two), .threeOfAKind)
+    }
 }


### PR DESCRIPTION
## Summary

`Hand.evaluate()` ignores wild cards, so a hand like 9♦ 2♦ 5♦ 4♠ 8♣ in Deuces Wild mode returned `.highCard` instead of `.pair`. This caused the pre-draw rank label in the app to display "High Card" when it should show "Pair".

## Changes

- Added `Hand.evaluate(wildcardRank: Rank?) -> HandType` overload
  - When `wildcardRank` is nil, delegates to the existing `evaluate()`
  - Supports 5+ cards, matching `evaluate()`: for 6-7 card hands it searches all 5-card combinations and returns the best result
  - For winning hands, derives `HandType` from `HandResult.evaluate(cards:wildcardRank:)` (already wildcard-aware)
  - For non-paying hands (`.noWin`), uses the standard evaluator and upgrades `.highCard` to `.pair` when a wild card is held
- Clarified `HandResult.handType`'s doc comment to note the mapping is lossy for wild-only results (`.fiveOfAKind`/`.fourDeuces` maps to `.fourOfAKind`, `.wildRoyalFlush`/`.naturalRoyalFlush` maps to `.royalFlush`)
- New tests in `HandTests` and `DeucesWildTests` covering 6/7-card wildcard evaluation and the lossy `handType` mapping

## Tests

164 tests pass.
