### PR TITLE
Add PayTableAnalyzer: combinatorial index, outcome-count arrays, and exact RTP computation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,4 @@ jobs:
           echo "$HOME/.local/share/swiftly/bin" >> $GITHUB_PATH
 
       - name: Run tests
-        run: swift test
+        run: swift test -c release

--- a/.mise.toml
+++ b/.mise.toml
@@ -16,7 +16,7 @@ run = "prek run --all-files"
 
 [tasks.test]
 description = "Run the Swift test suite"
-run = "swift test"
+run = "swift test -c release"
 
 [tasks.build]
 description = "Build the Swift package"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ After install, `mise exec -- swiftlint lint` and `mise exec -- swiftformat --lin
 - Write tests for all logic branches, including edge cases.
 - Poker hand evaluation must cover: all hand types, wheel straights (A-2-3-4-5), ace-high straights, tie-breaking, and 5+ card hand evaluation (Texas Hold'em style).
 - SwiftUI components: use text-based representations for validation in headless CI. No pixel-perfect image comparisons.
-- Run `swift test` before every PR. Fix all failures before submitting.
+- Run `swift test -c release` before every PR (matches CI; the default debug build is far slower for the exhaustive pay-table tests). Fix all failures before submitting.
 
 ## Card and Game Logic Rules
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ mise run test
 |------|-------------|
 | `mise install` | Install SwiftLint, SwiftFormat, prek, and register git hooks |
 | `mise run build` | `swift build` |
-| `mise run test` | `swift test` |
+| `mise run test` | `swift test -c release` |
 | `mise run lint` | Run all hooks via `prek run --all-files` |
 
 ## Quick Start
@@ -253,6 +253,11 @@ swift test                          # Run all tests
 swift test --filter HandTests      # Run specific test class
 swift test --parallel              # Run tests in parallel
 ```
+
+`HandOutcomeArraysTests` and `PayTableAnalyzerTests` exhaustively enumerate all
+2,598,960 possible 5-card hands and are much faster with optimizations enabled
+(`swift test -c release`, what CI and `mise run test` use) than in the default debug
+build.
 
 Generate sample card representations:
 ```bash

--- a/Sources/PlayingCard/CombinatorialIndex.swift
+++ b/Sources/PlayingCard/CombinatorialIndex.swift
@@ -1,0 +1,47 @@
+/// Combinatorial-number-system helpers used to translate a set of card indices into a
+/// dense array index, and back again. This is the indexing scheme described in the
+/// "One Second Program" section of
+/// https://wizardofodds.com/games/video-poker/methodology/: scoring every possible
+/// 5-card hand once and storing outcome counts in arrays keyed by the held cards'
+/// combinatorial index, rather than re-enumerating draw completions for every dealt
+/// hand.
+enum CombinatorialIndex {
+    // swiftlint:disable identifier_name
+    /// Returns `n choose k` (the binomial coefficient), or 0 when `k` is out of range.
+    ///
+    /// Cards are encoded as small integers (0..<52 in this library), and holds are at
+    /// most 5 cards, so `k` never exceeds single digits; a direct multiplicative
+    /// computation is simpler and cheap enough here that a precomputed lookup table
+    /// would be premature.
+    static func choose(_ n: Int, _ k: Int) -> Int {
+        guard k >= 0, k <= n else { return 0 }
+        if k == 0 || k == n {
+            return 1
+        }
+        var result = 1
+        for i in 0 ..< k {
+            result = result * (n - i) / (i + 1)
+        }
+        return result
+    }
+
+    // swiftlint:enable identifier_name
+
+    /// Returns the 0-based combinatorial-number-system index of an ascending, unique
+    /// set of card indices, among all `choose(52, cards.count)` possible combinations.
+    ///
+    /// For sorted `c(0) < c(1) < ... < c(k-1)`, the index is
+    /// `sum(choose(c(i), i + 1))` for `i` in `0..<k`. This is a standard bijection
+    /// between k-subsets of `0..<n` and `0..<choose(n, k)`; see
+    /// `CombinatorialIndexTests` for the exhaustive bijection check.
+    ///
+    /// - Parameter sortedCards: Card indices in strictly ascending order. Any range of
+    ///   distinct non-negative integers works; this library uses `0..<52`.
+    static func index(sortedCards: [Int]) -> Int {
+        var index = 0
+        for (position, card) in sortedCards.enumerated() {
+            index += choose(card, position + 1)
+        }
+        return index
+    }
+}

--- a/Sources/PlayingCard/CombinatorialIndex.swift
+++ b/Sources/PlayingCard/CombinatorialIndex.swift
@@ -7,13 +7,25 @@
 /// hand.
 enum CombinatorialIndex {
     // swiftlint:disable identifier_name
-    /// Returns `n choose k` (the binomial coefficient), or 0 when `k` is out of range.
+    /// Maximum subset size this library ever indexes (holds are at most 5 cards).
+    private static let maxK = 5
+
+    /// Precomputed `choose(n, k)` for every `n` in `0...52` and `k` in `0...maxK`,
+    /// built once on first access.
     ///
-    /// Cards are encoded as small integers (0..<52 in this library), and holds are at
-    /// most 5 cards, so `k` never exceeds single digits; a direct multiplicative
-    /// computation is simpler and cheap enough here that a precomputed lookup table
-    /// would be premature.
-    static func choose(_ n: Int, _ k: Int) -> Int {
+    /// `PayTableAnalyzer.overallReturn` calls `index(sortedCards:)` (and therefore
+    /// `choose`) on the order of a few billion times per pay table (2,598,960 hands,
+    /// up to 32 hold subsets each, up to 32 discard subsets per hold); a naive
+    /// multiplicative recomputation per call was measured to make that computation
+    /// roughly two orders of magnitude slower than it needed to be, so a lookup table
+    /// replaces the O(k) multiplicative loop with an O(1) array read.
+    private static let chooseTable: [[Int]] = (0 ... 52).map { n in
+        (0 ... maxK).map { k in computeChoose(n, k) }
+    }
+
+    /// The multiplicative binomial-coefficient computation `choose` uses to build
+    /// `chooseTable`. Not used directly outside table construction; see `choose`.
+    private static func computeChoose(_ n: Int, _ k: Int) -> Int {
         guard k >= 0, k <= n else { return 0 }
         if k == 0 || k == n {
             return 1
@@ -23,6 +35,17 @@ enum CombinatorialIndex {
             result = result * (n - i) / (i + 1)
         }
         return result
+    }
+
+    /// Returns `n choose k` (the binomial coefficient), or 0 when `k` is out of range.
+    ///
+    /// Cards are encoded as small integers (0..<52 in this library), and holds are at
+    /// most 5 cards, so this is always a lookup into `chooseTable`; falls back to a
+    /// direct computation for any `n`/`k` outside that table's range.
+    static func choose(_ n: Int, _ k: Int) -> Int {
+        guard k >= 0, k <= n else { return 0 }
+        guard n <= 52, k <= maxK else { return computeChoose(n, k) }
+        return chooseTable[n][k]
     }
 
     // swiftlint:enable identifier_name

--- a/Sources/PlayingCard/FastHandEvaluator.swift
+++ b/Sources/PlayingCard/FastHandEvaluator.swift
@@ -1,0 +1,386 @@
+/// Integer-encoded, allocation-free hand evaluators shared by `OptimalPlay`'s live
+/// per-hand hot loop and `HandOutcomeArrays`' one-time full-deck build pass.
+///
+/// Extracted from `OptimalPlay` so both consumers score a hand with exactly one
+/// implementation instead of duplicating this logic. Card encoding throughout:
+/// `(rank_index << 2) | suit_index`, where rank_index is 0 (two) through 12 (ace) and
+/// suit_index is 0–3.
+enum FastHandEvaluator {
+    // swiftlint:disable identifier_name cyclomatic_complexity function_body_length
+
+    /// Evaluates a 5-card hand encoded as integers and returns the `HandResult.rawValue`.
+    ///
+    /// Encoding per card: `(rank_index << 2) | suit_index`
+    /// where rank_index is 0 (two) through 12 (ace) and suit_index is 0–3.
+    @inline(__always)
+    static func standardCode(_ c0: Int, _ c1: Int, _ c2: Int, _ c3: Int, _ c4: Int) -> Int {
+        let rank0 = c0 >> 2, rank1 = c1 >> 2, rank2 = c2 >> 2, rank3 = c3 >> 2, rank4 = c4 >> 2
+        let suit0 = c0 & 3, suit1 = c1 & 3, suit2 = c2 & 3, suit3 = c3 & 3, suit4 = c4 & 3
+
+        let flush = suit0 == suit1 && suit1 == suit2 && suit2 == suit3 && suit3 == suit4
+
+        // Inline insertion sort of the 5 ranks using stack-allocated registers
+        var s0 = rank0, s1 = rank1, s2 = rank2, s3 = rank3, s4 = rank4
+        var t = 0
+
+        if s0 > s1 {
+            t = s0; s0 = s1; s1 = t
+        }
+
+        if s1 > s2 {
+            t = s1; s1 = s2; s2 = t
+            if s0 > s1 {
+                t = s0; s0 = s1; s1 = t
+            }
+        }
+
+        if s2 > s3 {
+            t = s2; s2 = s3; s3 = t
+            if s1 > s2 {
+                t = s1; s1 = s2; s2 = t
+                if s0 > s1 {
+                    t = s0; s0 = s1; s1 = t
+                }
+            }
+        }
+
+        if s3 > s4 {
+            t = s3; s3 = s4; s4 = t
+            if s2 > s3 {
+                t = s2; s2 = s3; s3 = t
+                if s1 > s2 {
+                    t = s1; s1 = s2; s2 = t
+                    if s0 > s1 {
+                        t = s0; s0 = s1; s1 = t
+                    }
+                }
+            }
+        }
+
+        // Distinct check for straight detection
+        let isDistinct = s0 != s1 && s1 != s2 && s2 != s3 && s3 != s4
+        var isStraight = false
+        var isRoyal = false
+
+        if isDistinct {
+            if s4 - s0 == 4 {
+                isStraight = true
+                if s3 == 11, s4 == 12 {
+                    isRoyal = true
+                }
+            } else if s0 == 0, s1 == 1, s2 == 2, s3 == 3, s4 == 12 {
+                isStraight = true
+            }
+        }
+
+        // Evaluate Hand Result in precedence order
+        if flush && isStraight && isRoyal {
+            return HandResult.royalFlush.rawValue
+        }
+        if flush && isStraight {
+            return HandResult.straightFlush.rawValue
+        }
+        if s0 == s3 || s1 == s4 {
+            return HandResult.fourOfAKind.rawValue
+        }
+        if (s0 == s2 && s3 == s4) || (s0 == s1 && s2 == s4) {
+            return HandResult.fullHouse.rawValue
+        }
+        if flush {
+            return HandResult.flush.rawValue
+        }
+        if isStraight {
+            return HandResult.straight.rawValue
+        }
+        if s0 == s2 || s1 == s3 || s2 == s4 {
+            return HandResult.threeOfAKind.rawValue
+        }
+        if (s0 == s1 && s2 == s3) || (s0 == s1 && s3 == s4) || (s1 == s2 && s3 == s4) {
+            return HandResult.twoPair.rawValue
+        }
+        if s0 == s1 {
+            return s1 >= 9 ? HandResult.jacksOrBetter.rawValue : HandResult.noWin.rawValue
+        }
+        if s1 == s2 {
+            return s2 >= 9 ? HandResult.jacksOrBetter.rawValue : HandResult.noWin.rawValue
+        }
+        if s2 == s3 {
+            return s3 >= 9 ? HandResult.jacksOrBetter.rawValue : HandResult.noWin.rawValue
+        }
+        if s3 == s4 {
+            return s4 >= 9 ? HandResult.jacksOrBetter.rawValue : HandResult.noWin.rawValue
+        }
+
+        return HandResult.noWin.rawValue
+    }
+
+    /// Deuces Wild hand evaluator. Treats rank_index 0 (the physical 2) as a wildcard that
+    /// substitutes for any card (any rank and suit).
+    ///
+    /// Evaluation priority: naturalRoyalFlush > fourDeuces > wildRoyalFlush > fiveOfAKind >
+    /// straightFlush > fourOfAKind > fullHouse > flush > straight > threeOfAKind > noWin.
+    ///
+    /// For k=0, delegates to `standardCode` and remaps the result to DW conventions
+    /// (royal flush → naturalRoyalFlush; pair/two-pair → noWin).
+    @inline(__always)
+    static func deucesWildCode(
+        _ c0: Int, _ c1: Int, _ c2: Int, _ c3: Int, _ c4: Int,
+    ) -> Int {
+        // rank_index 0 = deuce = wild.
+        let r0 = c0 >> 2, r1 = c1 >> 2, r2 = c2 >> 2, r3 = c3 >> 2, r4 = c4 >> 2
+
+        // Count wildcards.
+        let k = (r0 == 0 ? 1 : 0) + (r1 == 0 ? 1 : 0) + (r2 == 0 ? 1 : 0)
+            + (r3 == 0 ? 1 : 0) + (r4 == 0 ? 1 : 0)
+
+        // k=4: Four Deuces.
+        if k == 4 {
+            return HandResult.fourDeuces.rawValue
+        }
+
+        // k=0: Standard JoB evaluation with DW remapping.
+        if k == 0 {
+            let base = standardCode(c0, c1, c2, c3, c4)
+            if base == HandResult.royalFlush.rawValue {
+                return HandResult.naturalRoyalFlush.rawValue
+            }
+            // Pair (jacksOrBetter=1) and two-pair (2) don't pay in DW.
+            return base <= 2 ? HandResult.noWin.rawValue : base
+        }
+
+        // k = 1, 2, or 3 — extract natural (non-wild) cards into fixed slots.
+        // n = 5 - k  (guaranteed 2–4 naturals).
+        // c0 is first: if r0 != 0, n is always 0 before this block.
+        var na0 = 0, na1 = 0, na2 = 0, na3 = 0 // natural rank indices
+        var ns0 = 0, ns1 = 0, ns2 = 0, ns3 = 0 // natural suit indices
+        var n = 0
+
+        if r0 != 0 {
+            na0 = r0; ns0 = c0 & 3; n = 1
+        }
+        if r1 != 0 {
+            switch n {
+            case 0: na0 = r1; ns0 = c1 & 3
+            case 1: na1 = r1; ns1 = c1 & 3
+            default: na2 = r1; ns2 = c1 & 3
+            }
+            n += 1
+        }
+        if r2 != 0 {
+            switch n {
+            case 0: na0 = r2; ns0 = c2 & 3
+            case 1: na1 = r2; ns1 = c2 & 3
+            case 2: na2 = r2; ns2 = c2 & 3
+            default: na3 = r2; ns3 = c2 & 3
+            }
+            n += 1
+        }
+        if r3 != 0 {
+            switch n {
+            case 0: na0 = r3; ns0 = c3 & 3
+            case 1: na1 = r3; ns1 = c3 & 3
+            case 2: na2 = r3; ns2 = c3 & 3
+            default: na3 = r3; ns3 = c3 & 3
+            }
+            n += 1
+        }
+        if r4 != 0 {
+            switch n {
+            case 0: na0 = r4; ns0 = c4 & 3
+            case 1: na1 = r4; ns1 = c4 & 3
+            case 2: na2 = r4; ns2 = c4 & 3
+            default: na3 = r4; ns3 = c4 & 3
+            }
+            n += 1
+        }
+
+        // Compute per-rank frequencies and distinct-rank count without allocation.
+        // Slots d0–d3 hold distinct rank values; f0–f3 hold their frequencies.
+        var d0 = -1, d1 = -1, d2 = -1, d3 = -1
+        var f0 = 0, f1 = 0, f2 = 0, f3 = 0
+        var dCount = 0
+
+        func countRank(_ r: Int) {
+            if r == d0 {
+                f0 += 1; return
+            }
+            if d0 == -1 {
+                d0 = r; f0 = 1; dCount = 1; return
+            }
+            if r == d1 {
+                f1 += 1; return
+            }
+            if d1 == -1 {
+                d1 = r; f1 = 1; dCount = 2; return
+            }
+            if r == d2 {
+                f2 += 1; return
+            }
+            if d2 == -1 {
+                d2 = r; f2 = 1; dCount = 3; return
+            }
+            if r == d3 {
+                f3 += 1; return
+            }
+            if d3 == -1 {
+                d3 = r; f3 = 1; dCount = 4; return
+            }
+        }
+
+        countRank(na0)
+        countRank(na1)
+        if n > 2 {
+            countRank(na2)
+        }
+        if n > 3 {
+            countRank(na3)
+        }
+
+        let maxFreq = max(f0, max(f1, max(f2, f3)))
+
+        // Wild Royal Flush: all naturals are royal (rank_idx 8–12 = T through A),
+        // all same suit, all distinct ranks. Wildcards fill remaining royal slots.
+        // n + k = 5 always, so wilds always fill exactly the missing royal positions.
+        if maxFreq == 1 { // distinct check shortcut: if all freqs are 1, ranks are distinct
+            let allRoyal = na0 >= 8 && na1 >= 8 && (n < 3 || na2 >= 8) && (n < 4 || na3 >= 8)
+            if allRoyal {
+                let suit = ns0
+                let allSameSuit =
+                    ns1 == suit && (n < 3 || ns2 == suit) && (n < 4 || ns3 == suit)
+                if allSameSuit {
+                    return HandResult.wildRoyalFlush.rawValue
+                }
+            }
+        }
+
+        // Five of a Kind: most-frequent rank + wildcards ≥ 5.
+        if maxFreq + k >= 5 {
+            return HandResult.fiveOfAKind.rawValue
+        }
+
+        // Straight Flush: all naturals share a suit, distinct ranks, fit in a 5-card window.
+        let sfSuit = ns0
+        let allSameSuit =
+            ns1 == sfSuit && (n < 3 || ns2 == sfSuit) && (n < 4 || ns3 == sfSuit)
+        if allSameSuit {
+            // distinct means dCount == n (all different ranks).
+            let rankDistinct = dCount == n
+            if rankDistinct {
+                if Self.dwCanFormStraightWindow(na0, na1, na2, na3, n: n) {
+                    return HandResult.straightFlush.rawValue
+                }
+            }
+        }
+
+        // Four of a Kind.
+        if maxFreq + k >= 4 {
+            return HandResult.fourOfAKind.rawValue
+        }
+
+        // Full House: at most 2 distinct natural ranks, wilds fill the gaps.
+        if dCount <= 2 {
+            var sortF1 = f0, sortF2 = f1
+            if dCount == 1 {
+                sortF2 = 0
+            }
+            if sortF1 < sortF2 {
+                let t = sortF1; sortF1 = sortF2; sortF2 = t
+            }
+            let wildsA = max(0, 3 - sortF1) + max(0, 2 - sortF2)
+            let wildsB = max(0, 2 - sortF1) + max(0, 3 - sortF2)
+            if min(wildsA, wildsB) <= k {
+                return HandResult.fullHouse.rawValue
+            }
+        }
+
+        // Flush: all naturals same suit (SF already failed, so no straight window).
+        if allSameSuit {
+            return HandResult.flush.rawValue
+        }
+
+        // Straight: distinct natural ranks fit in a 5-card window (suit-agnostic).
+        if dCount == n { // all distinct
+            if Self.dwCanFormStraightWindow(na0, na1, na2, na3, n: n) {
+                return HandResult.straight.rawValue
+            }
+        }
+
+        // Three of a Kind: most-frequent rank + wildcards ≥ 3.
+        if maxFreq + k >= 3 {
+            return HandResult.threeOfAKind.rawValue
+        }
+
+        return HandResult.noWin.rawValue
+    }
+
+    /// Returns true when `n` natural rank indices (na0…na(n-1)) fit inside a 5-card
+    /// straight window using wildcards to fill the remaining positions.
+    ///
+    /// Handles both the standard case (span ≤ 4) and the wheel A-2-3-4-5
+    /// (rank_index 12 = Ace, with the 2 being wild and naturals in {1,2,3} = ranks 3,4,5).
+    @inline(__always)
+    static func dwCanFormStraightWindow(
+        _ na0: Int, _ na1: Int, _ na2: Int, _ na3: Int, n: Int,
+    ) -> Bool {
+        var lo = na0, hi = na0
+        if na1 < lo {
+            lo = na1
+        } else if na1 > hi {
+            hi = na1
+        }
+        if n > 2 {
+            if na2 < lo {
+                lo = na2
+            } else if na2 > hi {
+                hi = na2
+            }
+        }
+        if n > 3 {
+            if na3 < lo {
+                lo = na3
+            } else if na3 > hi {
+                hi = na3
+            }
+        }
+
+        let span = hi - lo
+        if span <= 4 {
+            return true
+        }
+
+        // Wheel: Ace (rank_index 12) + naturals in {1, 2, 3} (actual ranks 3–5).
+        // The 2 (rank_index 0) is always wild, so naturals can't contribute rank_index 0.
+        if hi == 12 { // ace present
+            let nonAceOK =
+                Self.dwAllInWheelRange(na0, na1, na2, na3, n: n, lo: lo)
+            if nonAceOK {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Returns true when all non-ace natural ranks (rank_idx != 12) are in [1, 3].
+    @inline(__always)
+    static func dwAllInWheelRange(
+        _ na0: Int, _ na1: Int, _ na2: Int, _ na3: Int, n: Int, lo: Int,
+    ) -> Bool {
+        /// lo is the minimum rank_index; if lo == 12 all cards are aces (impossible for n>1).
+        func inRange(_ r: Int) -> Bool {
+            r == 12 || (r >= 1 && r <= 3)
+        }
+        if !inRange(na0) || !inRange(na1) {
+            return false
+        }
+        if n > 2, !inRange(na2) {
+            return false
+        }
+        if n > 3, !inRange(na3) {
+            return false
+        }
+        _ = lo
+        return true
+    }
+
+    // swiftlint:enable identifier_name cyclomatic_complexity function_body_length
+}

--- a/Sources/PlayingCard/FastHandEvaluator.swift
+++ b/Sources/PlayingCard/FastHandEvaluator.swift
@@ -148,7 +148,7 @@ enum FastHandEvaluator {
             return base <= 2 ? HandResult.noWin.rawValue : base
         }
 
-        // k = 1, 2, or 3 — extract natural (non-wild) cards into fixed slots.
+        // k = 1, 2, or 3: extract natural (non-wild) cards into fixed slots.
         // n = 5 - k  (guaranteed 2–4 naturals).
         // c0 is first: if r0 != 0, n is always 0 before this block.
         var na0 = 0, na1 = 0, na2 = 0, na3 = 0 // natural rank indices

--- a/Sources/PlayingCard/HandOutcomeArrays.swift
+++ b/Sources/PlayingCard/HandOutcomeArrays.swift
@@ -198,4 +198,61 @@ struct HandOutcomeArrays {
         let start = index * Self.resultCount
         return (0 ..< Self.resultCount).map { Int(flat[start + $0]) }
     }
+
+    // swiftlint:disable large_tuple cyclomatic_complexity
+    /// Returns the total payout (`Σ count * multiplier`) for the count row addressed by
+    /// a specific subset of a 5-card hand, without materializing an intermediate row
+    /// array or a subset-cards array.
+    ///
+    /// `mask`'s bit `i` selects `cards`'s element `i` (`cards.0` for bit 0, `cards.4`
+    /// for bit 4); `cards` must be in ascending order, matching every other
+    /// subset-index computation in this type. `multipliers` must have `resultCount`
+    /// entries, indexed by `HandResult.rawValue`.
+    ///
+    /// This is the hot-path counterpart to `outcomeCounts`/`rowCounts`:
+    /// `PayTableAnalyzer` calls this on the order of a few hundred million times per
+    /// pay table (2,598,960 hands times up to 32 subsets each), so avoiding per-call
+    /// heap allocation is what makes that computation tractable — a first
+    /// implementation built on `outcomeCounts` directly measured at roughly two orders
+    /// of magnitude slower, entirely from Array allocation/ARC overhead, not from the
+    /// combinatorial-index arithmetic itself.
+    func payout(forSubsetMask mask: Int, cards: (Int, Int, Int, Int, Int), multipliers: [Double]) -> Double {
+        var index = 0
+        var position = 0
+        if mask & 0b00001 != 0 {
+            position += 1; index += CombinatorialIndex.choose(cards.0, position)
+        }
+        if mask & 0b00010 != 0 {
+            position += 1; index += CombinatorialIndex.choose(cards.1, position)
+        }
+        if mask & 0b00100 != 0 {
+            position += 1; index += CombinatorialIndex.choose(cards.2, position)
+        }
+        if mask & 0b01000 != 0 {
+            position += 1; index += CombinatorialIndex.choose(cards.3, position)
+        }
+        if mask & 0b10000 != 0 {
+            position += 1; index += CombinatorialIndex.choose(cards.4, position)
+        }
+
+        switch position {
+        case 5: return multipliers[Int(scoreForFiveCardHand[index])]
+        case 4: return dotProduct(countsForFourHeld, rowIndex: index, multipliers: multipliers)
+        case 3: return dotProduct(countsForThreeHeld, rowIndex: index, multipliers: multipliers)
+        case 2: return dotProduct(countsForTwoHeld, rowIndex: index, multipliers: multipliers)
+        case 1: return dotProduct(countsForOneHeld, rowIndex: index, multipliers: multipliers)
+        default: return dotProduct(countsForNoneHeld, rowIndex: 0, multipliers: multipliers)
+        }
+    }
+
+    // swiftlint:enable large_tuple cyclomatic_complexity
+
+    private func dotProduct(_ flat: [Int32], rowIndex: Int, multipliers: [Double]) -> Double {
+        let start = rowIndex * Self.resultCount
+        var sum = 0.0
+        for resultIndex in 0 ..< Self.resultCount {
+            sum += Double(flat[start + resultIndex]) * multipliers[resultIndex]
+        }
+        return sum
+    }
 }

--- a/Sources/PlayingCard/HandOutcomeArrays.swift
+++ b/Sources/PlayingCard/HandOutcomeArrays.swift
@@ -1,0 +1,201 @@
+/// Precomputed hand-outcome counts for one wildcard mode (standard/no-wild evaluation,
+/// or Deuces-Wild-style evaluation), built once by scoring every one of the 2,598,960
+/// possible 5-card hands exactly once.
+///
+/// Implements the "One Second Program" technique described at
+/// https://wizardofodds.com/games/video-poker/methodology/: rather than re-enumerating
+/// every possible draw completion for a specific dealt hand (as `OptimalPlay.fastEV`
+/// does, looping up to `C(47, 5) = 1,533,939` times for the worst case), every one of
+/// the 2,598,960 raw 5-card hands is scored exactly once here, and the draw-outcome
+/// distribution for any specific hold on any specific dealt hand is later derived from
+/// these arrays via inclusion-exclusion (`outcomeCounts(held:discarded:)`), with no
+/// per-hand re-enumeration of draw completions.
+///
+/// This is a standalone building block: nothing in `OptimalPlay`'s live per-hand hot
+/// path uses it yet. It exists to support `PayTableAnalyzer`'s exact whole-pay-table RTP
+/// computation, and as a spike for a possible future `OptimalPlay` fast path once
+/// benchmarked against the existing direct-enumeration approach.
+struct HandOutcomeArrays {
+    /// Number of distinct `HandResult` cases. Every count row has this many columns,
+    /// indexed by `HandResult.rawValue`.
+    static let resultCount = HandResult.allCases.count
+
+    /// Hand-result score for each of the `C(52, 5)` possible 5-card hands, indexed by
+    /// `CombinatorialIndex.index(sortedCards:)` of the 5 sorted card codes. One entry
+    /// per hand, since holding all 5 cards has a single, deterministic outcome (no
+    /// cards are drawn).
+    let scoreForFiveCardHand: [UInt8]
+
+    /// Flattened score-count table for held 4-card subsets. Row `i` (of `C(52, 4)` rows,
+    /// stride `resultCount`) holds, for each `HandResult.rawValue`, how many of the 48
+    /// cards not in that 4-card subset would produce that result as the 5th card.
+    let countsForFourHeld: [Int32]
+
+    /// Same shape as `countsForFourHeld`, for held 3-card subsets (`C(52, 3)` rows, over
+    /// the `C(49, 2)` possible pairs completing the hand).
+    let countsForThreeHeld: [Int32]
+
+    /// Same shape, for held 2-card subsets (`C(52, 2)` rows, over `C(50, 3)` completions).
+    let countsForTwoHeld: [Int32]
+
+    /// Same shape, for held 1-card subsets (52 rows, over `C(51, 4)` completions).
+    let countsForOneHeld: [Int32]
+
+    /// Same shape, a single row: the score-count distribution over all `C(52, 5)` hands
+    /// when holding no cards at all.
+    let countsForNoneHeld: [Int32]
+
+    // swiftlint:disable identifier_name function_body_length
+    /// Scores every one of the `C(52, 5) = 2,598,960` possible 5-card hands exactly
+    /// once, and buckets the result into the six count arrays above.
+    ///
+    /// This is a one-time, relatively expensive pass — see `HandOutcomeArraysTests`
+    /// for measured timing. Callers should build once per wildcard mode and reuse the
+    /// result rather than rebuilding per hand.
+    ///
+    /// - Parameter wildcardRank: `nil` for standard (Jacks-or-Better-style) evaluation,
+    ///   or `.two` for Deuces-Wild-style evaluation. Matches the same restriction as
+    ///   `OptimalPlay`, since the fast evaluators hard-code rank-index 0 for wild
+    ///   detection.
+    static func build(wildcardRank: Rank?) -> HandOutcomeArrays {
+        precondition(
+            wildcardRank == nil || wildcardRank == .two,
+            "HandOutcomeArrays only supports wildcardRank == .two (Deuces Wild). "
+                + "The fast evaluators hard-code rank-index 0 for wild detection.",
+        )
+        let isWild = wildcardRank != nil
+        let n = resultCount
+
+        var scoreForFiveCardHand = [UInt8](repeating: 0, count: CombinatorialIndex.choose(52, 5))
+        var countsForFourHeld = [Int32](repeating: 0, count: CombinatorialIndex.choose(52, 4) * n)
+        var countsForThreeHeld = [Int32](repeating: 0, count: CombinatorialIndex.choose(52, 3) * n)
+        var countsForTwoHeld = [Int32](repeating: 0, count: CombinatorialIndex.choose(52, 2) * n)
+        var countsForOneHeld = [Int32](repeating: 0, count: 52 * n)
+        var countsForNoneHeld = [Int32](repeating: 0, count: n)
+
+        for c0 in 0 ..< 52 {
+            for c1 in (c0 + 1) ..< 52 {
+                for c2 in (c1 + 1) ..< 52 {
+                    for c3 in (c2 + 1) ..< 52 {
+                        for c4 in (c3 + 1) ..< 52 {
+                            let score = isWild
+                                ? FastHandEvaluator.deucesWildCode(c0, c1, c2, c3, c4)
+                                : FastHandEvaluator.standardCode(c0, c1, c2, c3, c4)
+
+                            let cards = [c0, c1, c2, c3, c4]
+                            let index5 = CombinatorialIndex.index(sortedCards: cards)
+                            scoreForFiveCardHand[index5] = UInt8(score)
+                            countsForNoneHeld[score] += 1
+
+                            for excluded in 0 ..< 5 {
+                                var four = cards
+                                four.remove(at: excluded)
+                                let idx4 = CombinatorialIndex.index(sortedCards: four)
+                                countsForFourHeld[idx4 * n + score] += 1
+                            }
+
+                            for i in 0 ..< 5 {
+                                for j in (i + 1) ..< 5 {
+                                    let two = [cards[i], cards[j]]
+                                    let idx2 = CombinatorialIndex.index(sortedCards: two)
+                                    countsForTwoHeld[idx2 * n + score] += 1
+
+                                    for k in (j + 1) ..< 5 {
+                                        let three = [cards[i], cards[j], cards[k]]
+                                        let idx3 = CombinatorialIndex.index(sortedCards: three)
+                                        countsForThreeHeld[idx3 * n + score] += 1
+                                    }
+                                }
+                            }
+
+                            for card in cards {
+                                countsForOneHeld[card * n + score] += 1
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return HandOutcomeArrays(
+            scoreForFiveCardHand: scoreForFiveCardHand,
+            countsForFourHeld: countsForFourHeld,
+            countsForThreeHeld: countsForThreeHeld,
+            countsForTwoHeld: countsForTwoHeld,
+            countsForOneHeld: countsForOneHeld,
+            countsForNoneHeld: countsForNoneHeld,
+        )
+    }
+
+    // swiftlint:enable identifier_name function_body_length
+
+    // swiftlint:disable identifier_name
+    /// Derives the `HandResult`-bucketed outcome-count distribution for holding exactly
+    /// `held` from a specific dealt hand, permanently discarding `discarded` (the
+    /// other cards in that hand), via inclusion-exclusion over the discard set.
+    ///
+    /// `held` and `discarded` together must be exactly the 5 dealt cards (any card
+    /// codes, in any order) with no overlap. The returned array has `resultCount`
+    /// entries, indexed by `HandResult.rawValue`; entry `i` is the number of ways to
+    /// complete the hand (by drawing replacements for `discarded` from the remaining
+    /// 47-card deck) that produce `HandResult(rawValue: i)`.
+    ///
+    /// Uses the general inclusion-exclusion identity: for held set `H` and discard set
+    /// `D`, the true outcome distribution for holding exactly `H` is
+    /// `sum over subsets S of D of (-1)^|S| * rawCounts(H union S)`, where `rawCounts`
+    /// looks up the precomputed array matching `|H union S|` (5, 4, 3, 2, 1, or 0 cards
+    /// held). This generalizes the specific hold=4/3/2/1/0 formulas from the WoO
+    /// methodology page into one recursive rule, since each precomputed array
+    /// (`countsForFourHeld`, etc.) was built assuming no cards are excluded from the
+    /// draw pool, and must have every specific discarded card's contribution subtracted
+    /// (or added back, for even-sized subsets) to correct for that.
+    func outcomeCounts(held: [Int], discarded: [Int]) -> [Int] {
+        precondition(held.count + discarded.count == 5, "held and discarded must total 5 cards")
+        var totals = [Int](repeating: 0, count: Self.resultCount)
+
+        for subsetMask in 0 ..< (1 << discarded.count) {
+            var subset: [Int] = []
+            for bit in 0 ..< discarded.count where subsetMask & (1 << bit) != 0 {
+                subset.append(discarded[bit])
+            }
+            let sign = subset.count.isMultiple(of: 2) ? 1 : -1
+            let combined = (held + subset).sorted()
+            let row = rowCounts(forSortedCards: combined)
+            for i in 0 ..< Self.resultCount {
+                totals[i] += sign * row[i]
+            }
+        }
+        return totals
+    }
+
+    // swiftlint:enable identifier_name
+
+    /// Returns the `resultCount`-wide count row for a specific sorted set of held
+    /// cards, dispatching to whichever precomputed array matches its size.
+    private func rowCounts(forSortedCards combined: [Int]) -> [Int] {
+        switch combined.count {
+        case 5:
+            var row = [Int](repeating: 0, count: Self.resultCount)
+            let index = CombinatorialIndex.index(sortedCards: combined)
+            row[Int(scoreForFiveCardHand[index])] = 1
+            return row
+        case 4:
+            return extractRow(countsForFourHeld, index: CombinatorialIndex.index(sortedCards: combined))
+        case 3:
+            return extractRow(countsForThreeHeld, index: CombinatorialIndex.index(sortedCards: combined))
+        case 2:
+            return extractRow(countsForTwoHeld, index: CombinatorialIndex.index(sortedCards: combined))
+        case 1:
+            return extractRow(countsForOneHeld, index: CombinatorialIndex.index(sortedCards: combined))
+        case 0:
+            return countsForNoneHeld.map(Int.init)
+        default:
+            preconditionFailure("combined held+subset count must be 0–5, got \(combined.count)")
+        }
+    }
+
+    private func extractRow(_ flat: [Int32], index: Int) -> [Int] {
+        let start = index * Self.resultCount
+        return (0 ..< Self.resultCount).map { Int(flat[start + $0]) }
+    }
+}

--- a/Sources/PlayingCard/HandOutcomeArrays.swift
+++ b/Sources/PlayingCard/HandOutcomeArrays.swift
@@ -49,7 +49,7 @@ struct HandOutcomeArrays {
     /// Scores every one of the `C(52, 5) = 2,598,960` possible 5-card hands exactly
     /// once, and buckets the result into the six count arrays above.
     ///
-    /// This is a one-time, relatively expensive pass — see `HandOutcomeArraysTests`
+    /// This is a one-time, relatively expensive pass, see `HandOutcomeArraysTests`
     /// for measured timing. Callers should build once per wildcard mode and reuse the
     /// result rather than rebuilding per hand.
     ///
@@ -151,6 +151,12 @@ struct HandOutcomeArrays {
     /// (or added back, for even-sized subsets) to correct for that.
     func outcomeCounts(held: [Int], discarded: [Int]) -> [Int] {
         precondition(held.count + discarded.count == 5, "held and discarded must total 5 cards")
+        let combined = Set(held + discarded)
+        precondition(
+            combined.count == held.count + discarded.count,
+            "held and discarded must be disjoint and each contain no duplicate cards",
+        )
+        precondition(combined.allSatisfy { (0 ..< 52).contains($0) }, "held and discarded must contain valid card codes (0..<52)")
         var totals = [Int](repeating: 0, count: Self.resultCount)
 
         for subsetMask in 0 ..< (1 << discarded.count) {
@@ -212,7 +218,7 @@ struct HandOutcomeArrays {
     /// This is the hot-path counterpart to `outcomeCounts`/`rowCounts`:
     /// `PayTableAnalyzer` calls this on the order of a few hundred million times per
     /// pay table (2,598,960 hands times up to 32 subsets each), so avoiding per-call
-    /// heap allocation is what makes that computation tractable — a first
+    /// heap allocation is what makes that computation tractable. A first
     /// implementation built on `outcomeCounts` directly measured at roughly two orders
     /// of magnitude slower, entirely from Array allocation/ARC overhead, not from the
     /// combinatorial-index arithmetic itself.

--- a/Sources/PlayingCard/OptimalPlay.swift
+++ b/Sources/PlayingCard/OptimalPlay.swift
@@ -293,11 +293,11 @@ public struct OptimalPlay {
 
                 switch drawCount {
                 case 0:
-                    return Double(mults[handResultCode(h0, h1, h2, h3, h4)])
+                    return Double(mults[FastHandEvaluator.standardCode(h0, h1, h2, h3, h4)])
 
                 case 1:
                     for i in 0 ..< count {
-                        total += mults[handResultCode(h0, h1, h2, h3, rem[i])]
+                        total += mults[FastHandEvaluator.standardCode(h0, h1, h2, h3, rem[i])]
                     }
                     return Double(total) / Double(count)
 
@@ -305,7 +305,7 @@ public struct OptimalPlay {
                     for i in 0 ..< count - 1 {
                         let card0 = rem[i]
                         for j in i + 1 ..< count {
-                            total += mults[handResultCode(h0, h1, h2, card0, rem[j])]
+                            total += mults[FastHandEvaluator.standardCode(h0, h1, h2, card0, rem[j])]
                         }
                     }
                     let comboCount = (count * (count - 1)) / 2
@@ -317,7 +317,7 @@ public struct OptimalPlay {
                         for j in i + 1 ..< count - 1 {
                             let card1 = rem[j]
                             for k in j + 1 ..< count {
-                                total += mults[handResultCode(h0, h1, card0, card1, rem[k])]
+                                total += mults[FastHandEvaluator.standardCode(h0, h1, card0, card1, rem[k])]
                             }
                         }
                     }
@@ -332,7 +332,7 @@ public struct OptimalPlay {
                             for k in j + 1 ..< count - 1 {
                                 let card2 = rem[k]
                                 for l in k + 1 ..< count {
-                                    total += mults[handResultCode(h0, card0, card1, card2, rem[l])]
+                                    total += mults[FastHandEvaluator.standardCode(h0, card0, card1, card2, rem[l])]
                                 }
                             }
                         }
@@ -350,7 +350,7 @@ public struct OptimalPlay {
                                 for l in k + 1 ..< count - 1 {
                                     let card3 = rem[l]
                                     for m in l + 1 ..< count {
-                                        total += mults[handResultCode(card0, card1, card2, card3, rem[m])]
+                                        total += mults[FastHandEvaluator.standardCode(card0, card1, card2, card3, rem[m])]
                                     }
                                 }
                             }
@@ -366,116 +366,10 @@ public struct OptimalPlay {
         }
     }
 
-    /// Evaluates a 5-card hand encoded as integers and returns the `HandResult.rawValue`.
-    ///
-    /// Encoding per card: `(rank_index << 2) | suit_index`
-    /// where rank_index is 0 (two) through 12 (ace) and suit_index is 0–3.
-    @inline(__always)
-    private func handResultCode(_ c0: Int, _ c1: Int, _ c2: Int, _ c3: Int, _ c4: Int) -> Int {
-        let rank0 = c0 >> 2, rank1 = c1 >> 2, rank2 = c2 >> 2, rank3 = c3 >> 2, rank4 = c4 >> 2
-        let suit0 = c0 & 3, suit1 = c1 & 3, suit2 = c2 & 3, suit3 = c3 & 3, suit4 = c4 & 3
-
-        let flush = suit0 == suit1 && suit1 == suit2 && suit2 == suit3 && suit3 == suit4
-
-        // Inline insertion sort of the 5 ranks using stack-allocated registers
-        var s0 = rank0, s1 = rank1, s2 = rank2, s3 = rank3, s4 = rank4
-        var t = 0
-
-        if s0 > s1 {
-            t = s0; s0 = s1; s1 = t
-        }
-
-        if s1 > s2 {
-            t = s1; s1 = s2; s2 = t
-            if s0 > s1 {
-                t = s0; s0 = s1; s1 = t
-            }
-        }
-
-        if s2 > s3 {
-            t = s2; s2 = s3; s3 = t
-            if s1 > s2 {
-                t = s1; s1 = s2; s2 = t
-                if s0 > s1 {
-                    t = s0; s0 = s1; s1 = t
-                }
-            }
-        }
-
-        if s3 > s4 {
-            t = s3; s3 = s4; s4 = t
-            if s2 > s3 {
-                t = s2; s2 = s3; s3 = t
-                if s1 > s2 {
-                    t = s1; s1 = s2; s2 = t
-                    if s0 > s1 {
-                        t = s0; s0 = s1; s1 = t
-                    }
-                }
-            }
-        }
-
-        // Distinct check for straight detection
-        let isDistinct = s0 != s1 && s1 != s2 && s2 != s3 && s3 != s4
-        var isStraight = false
-        var isRoyal = false
-
-        if isDistinct {
-            if s4 - s0 == 4 {
-                isStraight = true
-                if s3 == 11, s4 == 12 {
-                    isRoyal = true
-                }
-            } else if s0 == 0, s1 == 1, s2 == 2, s3 == 3, s4 == 12 {
-                isStraight = true
-            }
-        }
-
-        // Evaluate Hand Result in precedence order
-        if flush && isStraight && isRoyal {
-            return HandResult.royalFlush.rawValue
-        }
-        if flush && isStraight {
-            return HandResult.straightFlush.rawValue
-        }
-        if s0 == s3 || s1 == s4 {
-            return HandResult.fourOfAKind.rawValue
-        }
-        if (s0 == s2 && s3 == s4) || (s0 == s1 && s2 == s4) {
-            return HandResult.fullHouse.rawValue
-        }
-        if flush {
-            return HandResult.flush.rawValue
-        }
-        if isStraight {
-            return HandResult.straight.rawValue
-        }
-        if s0 == s2 || s1 == s3 || s2 == s4 {
-            return HandResult.threeOfAKind.rawValue
-        }
-        if (s0 == s1 && s2 == s3) || (s0 == s1 && s3 == s4) || (s1 == s2 && s3 == s4) {
-            return HandResult.twoPair.rawValue
-        }
-        if s0 == s1 {
-            return s1 >= 9 ? HandResult.jacksOrBetter.rawValue : HandResult.noWin.rawValue
-        }
-        if s1 == s2 {
-            return s2 >= 9 ? HandResult.jacksOrBetter.rawValue : HandResult.noWin.rawValue
-        }
-        if s2 == s3 {
-            return s3 >= 9 ? HandResult.jacksOrBetter.rawValue : HandResult.noWin.rawValue
-        }
-        if s3 == s4 {
-            return s4 >= 9 ? HandResult.jacksOrBetter.rawValue : HandResult.noWin.rawValue
-        }
-
-        return HandResult.noWin.rawValue
-    }
-
     // MARK: - Deuces Wild inner loop
 
     /// `fastEV` variant for Deuces Wild. Dispatches hand evaluation through
-    /// `handResultCodeDeuces` which treats rank_index 0 (the 2) as a wildcard.
+    /// `FastHandEvaluator.deucesWildCode` which treats rank_index 0 (the 2) as a wildcard.
     private func fastEVWild(handCodes: [Int], mask: Int, remaining: [Int]) -> Double {
         let c0 = handCodes[0], c1 = handCodes[1], c2 = handCodes[2], c3 = handCodes[3], c4 = handCodes[4]
         return multiplierTable.withUnsafeBufferPointer { multsBuf in
@@ -540,11 +434,11 @@ public struct OptimalPlay {
 
                 switch drawCount {
                 case 0:
-                    return Double(mults[handResultCodeDeuces(h0, h1, h2, h3, h4)])
+                    return Double(mults[FastHandEvaluator.deucesWildCode(h0, h1, h2, h3, h4)])
 
                 case 1:
                     for i in 0 ..< count {
-                        total += mults[handResultCodeDeuces(h0, h1, h2, h3, rem[i])]
+                        total += mults[FastHandEvaluator.deucesWildCode(h0, h1, h2, h3, rem[i])]
                     }
                     return Double(total) / Double(count)
 
@@ -552,7 +446,7 @@ public struct OptimalPlay {
                     for i in 0 ..< count - 1 {
                         let card0 = rem[i]
                         for j in i + 1 ..< count {
-                            total += mults[handResultCodeDeuces(h0, h1, h2, card0, rem[j])]
+                            total += mults[FastHandEvaluator.deucesWildCode(h0, h1, h2, card0, rem[j])]
                         }
                     }
                     let comboCount = (count * (count - 1)) / 2
@@ -564,7 +458,7 @@ public struct OptimalPlay {
                         for j in i + 1 ..< count - 1 {
                             let card1 = rem[j]
                             for k in j + 1 ..< count {
-                                total += mults[handResultCodeDeuces(h0, h1, card0, card1, rem[k])]
+                                total += mults[FastHandEvaluator.deucesWildCode(h0, h1, card0, card1, rem[k])]
                             }
                         }
                     }
@@ -579,7 +473,7 @@ public struct OptimalPlay {
                             for k in j + 1 ..< count - 1 {
                                 let card2 = rem[k]
                                 for l in k + 1 ..< count {
-                                    total += mults[handResultCodeDeuces(h0, card0, card1, card2, rem[l])]
+                                    total += mults[FastHandEvaluator.deucesWildCode(h0, card0, card1, card2, rem[l])]
                                 }
                             }
                         }
@@ -597,7 +491,7 @@ public struct OptimalPlay {
                                 for l in k + 1 ..< count - 1 {
                                     let card3 = rem[l]
                                     for m in l + 1 ..< count {
-                                        total += mults[handResultCodeDeuces(card0, card1, card2, card3, rem[m])]
+                                        total += mults[FastHandEvaluator.deucesWildCode(card0, card1, card2, card3, rem[m])]
                                     }
                                 }
                             }
@@ -611,274 +505,6 @@ public struct OptimalPlay {
                 }
             }
         }
-    }
-
-    /// Deuces Wild hand evaluator. Treats rank_index 0 (the physical 2) as a wildcard that
-    /// substitutes for any card (any rank and suit).
-    ///
-    /// Evaluation priority: naturalRoyalFlush > fourDeuces > wildRoyalFlush > fiveOfAKind >
-    /// straightFlush > fourOfAKind > fullHouse > flush > straight > threeOfAKind > noWin.
-    ///
-    /// For k=0, delegates to `handResultCode` and remaps the result to DW conventions
-    /// (royal flush → naturalRoyalFlush; pair/two-pair → noWin).
-    @inline(__always)
-    private func handResultCodeDeuces(
-        _ c0: Int, _ c1: Int, _ c2: Int, _ c3: Int, _ c4: Int,
-    ) -> Int {
-        // rank_index 0 = deuce = wild.
-        let r0 = c0 >> 2, r1 = c1 >> 2, r2 = c2 >> 2, r3 = c3 >> 2, r4 = c4 >> 2
-
-        // Count wildcards.
-        let k = (r0 == 0 ? 1 : 0) + (r1 == 0 ? 1 : 0) + (r2 == 0 ? 1 : 0)
-            + (r3 == 0 ? 1 : 0) + (r4 == 0 ? 1 : 0)
-
-        // k=4: Four Deuces.
-        if k == 4 {
-            return HandResult.fourDeuces.rawValue
-        }
-
-        // k=0: Standard JoB evaluation with DW remapping.
-        if k == 0 {
-            let base = handResultCode(c0, c1, c2, c3, c4)
-            if base == HandResult.royalFlush.rawValue {
-                return HandResult.naturalRoyalFlush.rawValue
-            }
-            // Pair (jacksOrBetter=1) and two-pair (2) don't pay in DW.
-            return base <= 2 ? HandResult.noWin.rawValue : base
-        }
-
-        // k = 1, 2, or 3 — extract natural (non-wild) cards into fixed slots.
-        // n = 5 - k  (guaranteed 2–4 naturals).
-        // c0 is first: if r0 != 0, n is always 0 before this block.
-        var na0 = 0, na1 = 0, na2 = 0, na3 = 0 // natural rank indices
-        var ns0 = 0, ns1 = 0, ns2 = 0, ns3 = 0 // natural suit indices
-        var n = 0
-
-        if r0 != 0 {
-            na0 = r0; ns0 = c0 & 3; n = 1
-        }
-        if r1 != 0 {
-            switch n {
-            case 0: na0 = r1; ns0 = c1 & 3
-            case 1: na1 = r1; ns1 = c1 & 3
-            default: na2 = r1; ns2 = c1 & 3
-            }
-            n += 1
-        }
-        if r2 != 0 {
-            switch n {
-            case 0: na0 = r2; ns0 = c2 & 3
-            case 1: na1 = r2; ns1 = c2 & 3
-            case 2: na2 = r2; ns2 = c2 & 3
-            default: na3 = r2; ns3 = c2 & 3
-            }
-            n += 1
-        }
-        if r3 != 0 {
-            switch n {
-            case 0: na0 = r3; ns0 = c3 & 3
-            case 1: na1 = r3; ns1 = c3 & 3
-            case 2: na2 = r3; ns2 = c3 & 3
-            default: na3 = r3; ns3 = c3 & 3
-            }
-            n += 1
-        }
-        if r4 != 0 {
-            switch n {
-            case 0: na0 = r4; ns0 = c4 & 3
-            case 1: na1 = r4; ns1 = c4 & 3
-            case 2: na2 = r4; ns2 = c4 & 3
-            default: na3 = r4; ns3 = c4 & 3
-            }
-            n += 1
-        }
-
-        // Compute per-rank frequencies and distinct-rank count without allocation.
-        // Slots d0–d3 hold distinct rank values; f0–f3 hold their frequencies.
-        var d0 = -1, d1 = -1, d2 = -1, d3 = -1
-        var f0 = 0, f1 = 0, f2 = 0, f3 = 0
-        var dCount = 0
-
-        func countRank(_ r: Int) {
-            if r == d0 {
-                f0 += 1; return
-            }
-            if d0 == -1 {
-                d0 = r; f0 = 1; dCount = 1; return
-            }
-            if r == d1 {
-                f1 += 1; return
-            }
-            if d1 == -1 {
-                d1 = r; f1 = 1; dCount = 2; return
-            }
-            if r == d2 {
-                f2 += 1; return
-            }
-            if d2 == -1 {
-                d2 = r; f2 = 1; dCount = 3; return
-            }
-            if r == d3 {
-                f3 += 1; return
-            }
-            if d3 == -1 {
-                d3 = r; f3 = 1; dCount = 4; return
-            }
-        }
-
-        countRank(na0)
-        countRank(na1)
-        if n > 2 {
-            countRank(na2)
-        }
-        if n > 3 {
-            countRank(na3)
-        }
-
-        let maxFreq = max(f0, max(f1, max(f2, f3)))
-
-        // Wild Royal Flush: all naturals are royal (rank_idx 8–12 = T through A),
-        // all same suit, all distinct ranks. Wildcards fill remaining royal slots.
-        // n + k = 5 always, so wilds always fill exactly the missing royal positions.
-        if maxFreq == 1 { // distinct check shortcut: if all freqs are 1, ranks are distinct
-            let allRoyal = na0 >= 8 && na1 >= 8 && (n < 3 || na2 >= 8) && (n < 4 || na3 >= 8)
-            if allRoyal {
-                let suit = ns0
-                let allSameSuit =
-                    ns1 == suit && (n < 3 || ns2 == suit) && (n < 4 || ns3 == suit)
-                if allSameSuit {
-                    return HandResult.wildRoyalFlush.rawValue
-                }
-            }
-        }
-
-        // Five of a Kind: most-frequent rank + wildcards ≥ 5.
-        if maxFreq + k >= 5 {
-            return HandResult.fiveOfAKind.rawValue
-        }
-
-        // Straight Flush: all naturals share a suit, distinct ranks, fit in a 5-card window.
-        let sfSuit = ns0
-        let allSameSuit =
-            ns1 == sfSuit && (n < 3 || ns2 == sfSuit) && (n < 4 || ns3 == sfSuit)
-        if allSameSuit {
-            // distinct means dCount == n (all different ranks).
-            let rankDistinct = dCount == n
-            if rankDistinct {
-                if dwCanFormStraightWindow(na0, na1, na2, na3, n: n) {
-                    return HandResult.straightFlush.rawValue
-                }
-            }
-        }
-
-        // Four of a Kind.
-        if maxFreq + k >= 4 {
-            return HandResult.fourOfAKind.rawValue
-        }
-
-        // Full House: at most 2 distinct natural ranks, wilds fill the gaps.
-        if dCount <= 2 {
-            var sortF1 = f0, sortF2 = f1
-            if dCount == 1 {
-                sortF2 = 0
-            }
-            if sortF1 < sortF2 {
-                let t = sortF1; sortF1 = sortF2; sortF2 = t
-            }
-            let wildsA = max(0, 3 - sortF1) + max(0, 2 - sortF2)
-            let wildsB = max(0, 2 - sortF1) + max(0, 3 - sortF2)
-            if min(wildsA, wildsB) <= k {
-                return HandResult.fullHouse.rawValue
-            }
-        }
-
-        // Flush: all naturals same suit (SF already failed, so no straight window).
-        if allSameSuit {
-            return HandResult.flush.rawValue
-        }
-
-        // Straight: distinct natural ranks fit in a 5-card window (suit-agnostic).
-        if dCount == n { // all distinct
-            if dwCanFormStraightWindow(na0, na1, na2, na3, n: n) {
-                return HandResult.straight.rawValue
-            }
-        }
-
-        // Three of a Kind: most-frequent rank + wildcards ≥ 3.
-        if maxFreq + k >= 3 {
-            return HandResult.threeOfAKind.rawValue
-        }
-
-        return HandResult.noWin.rawValue
-    }
-
-    /// Returns true when `n` natural rank indices (na0…na(n-1)) fit inside a 5-card
-    /// straight window using wildcards to fill the remaining positions.
-    ///
-    /// Handles both the standard case (span ≤ 4) and the wheel A-2-3-4-5
-    /// (rank_index 12 = Ace, with the 2 being wild and naturals in {1,2,3} = ranks 3,4,5).
-    @inline(__always)
-    private func dwCanFormStraightWindow(
-        _ na0: Int, _ na1: Int, _ na2: Int, _ na3: Int, n: Int,
-    ) -> Bool {
-        var lo = na0, hi = na0
-        if na1 < lo {
-            lo = na1
-        } else if na1 > hi {
-            hi = na1
-        }
-        if n > 2 {
-            if na2 < lo {
-                lo = na2
-            } else if na2 > hi {
-                hi = na2
-            }
-        }
-        if n > 3 {
-            if na3 < lo {
-                lo = na3
-            } else if na3 > hi {
-                hi = na3
-            }
-        }
-
-        let span = hi - lo
-        if span <= 4 {
-            return true
-        }
-
-        // Wheel: Ace (rank_index 12) + naturals in {1, 2, 3} (actual ranks 3–5).
-        // The 2 (rank_index 0) is always wild, so naturals can't contribute rank_index 0.
-        if hi == 12 { // ace present
-            let nonAceOK =
-                dwAllInWheelRange(na0, na1, na2, na3, n: n, lo: lo)
-            if nonAceOK {
-                return true
-            }
-        }
-        return false
-    }
-
-    /// Returns true when all non-ace natural ranks (rank_idx != 12) are in [1, 3].
-    @inline(__always)
-    private func dwAllInWheelRange(
-        _ na0: Int, _ na1: Int, _ na2: Int, _ na3: Int, n: Int, lo: Int,
-    ) -> Bool {
-        /// lo is the minimum rank_index; if lo == 12 all cards are aces (impossible for n>1).
-        func inRange(_ r: Int) -> Bool {
-            r == 12 || (r >= 1 && r <= 3)
-        }
-        if !inRange(na0) || !inRange(na1) {
-            return false
-        }
-        if n > 2, !inRange(na2) {
-            return false
-        }
-        if n > 3, !inRange(na3) {
-            return false
-        }
-        _ = lo
-        return true
     }
 
     // swiftlint:enable identifier_name cyclomatic_complexity function_body_length

--- a/Sources/PlayingCard/PayTableAnalyzer.swift
+++ b/Sources/PlayingCard/PayTableAnalyzer.swift
@@ -24,7 +24,7 @@ public enum PayTableAnalyzer {
     /// The overall return to player for `payTable` under exact optimal play, as a
     /// fraction of the amount bet (for example `0.995439` for 99.5439%).
     ///
-    /// This is a one-time, relatively expensive pass — see `PayTableAnalyzerTests` for
+    /// This is a one-time, relatively expensive pass, see `PayTableAnalyzerTests` for
     /// measured timing. It builds a fresh `HandOutcomeArrays` for `payTable`'s
     /// wildcard mode internally; computing returns for many pay tables that share a
     /// wildcard mode currently repeats that build per call, since `HandOutcomeArrays`

--- a/Sources/PlayingCard/PayTableAnalyzer.swift
+++ b/Sources/PlayingCard/PayTableAnalyzer.swift
@@ -31,6 +31,11 @@ public enum PayTableAnalyzer {
     /// is an internal implementation detail of this library, not part of its public
     /// API.
     public static func overallReturn(payTable: PayTable) -> Double {
+        precondition(
+            payTable.wildcardRank == nil || payTable.wildcardRank == .two,
+            "PayTableAnalyzer only supports wildcardRank == .two (Deuces Wild). "
+                + "The fast evaluator hard-codes rank-index 0 for wild detection.",
+        )
         let arrays = HandOutcomeArrays.build(wildcardRank: payTable.wildcardRank)
         let multipliers = HandResult.allCases.map { Double(payTable.multiplier(for: $0)) }
 

--- a/Sources/PlayingCard/PayTableAnalyzer.swift
+++ b/Sources/PlayingCard/PayTableAnalyzer.swift
@@ -1,0 +1,122 @@
+/// Computes exact return-to-player percentages for a `PayTable` under optimal play.
+///
+/// Implements the "One Second Program" technique described at
+/// https://wizardofodds.com/games/video-poker/methodology/, applied end to end: every
+/// one of the `C(52, 5) = 2,598,960` possible 5-card starting hands is evaluated, and
+/// for each, all 32 possible hold subsets are scored via `HandOutcomeArrays`'s
+/// precomputed outcome-count arrays via a Möbius (subset-sum) transform (no
+/// draw-completion enumeration, no per-hold or per-subset heap allocation). The best-EV
+/// hold for each starting hand is exactly the play a perfect-strategy player would
+/// make; averaging that best EV across all starting hands gives the pay table's exact
+/// overall return. Matches WoO's claimed timing: ~1.5s in a Release build.
+///
+/// This exists to compute the return percentage of a pay table the app doesn't already
+/// know the answer for, such as a user-entered custom pay table in the planned iPhone
+/// pay table editor, without falling back to a much slower Monte Carlo estimate.
+/// `PayTableAnalyzerTests` cross-checks its output against the published return
+/// percentages for this library's existing pay tables.
+public enum PayTableAnalyzer {
+    /// Number of possible draw completions for holding exactly `k` cards, indexed by
+    /// `k` (0...5): `C(47, 5 - k)`, since the draw pool always excludes the 5 originally
+    /// dealt cards regardless of which of them are held.
+    private static let completionsForHoldSize: [Int] = (0 ... 5).map { CombinatorialIndex.choose(47, 5 - $0) }
+
+    /// The overall return to player for `payTable` under exact optimal play, as a
+    /// fraction of the amount bet (for example `0.995439` for 99.5439%).
+    ///
+    /// This is a one-time, relatively expensive pass — see `PayTableAnalyzerTests` for
+    /// measured timing. It builds a fresh `HandOutcomeArrays` for `payTable`'s
+    /// wildcard mode internally; computing returns for many pay tables that share a
+    /// wildcard mode currently repeats that build per call, since `HandOutcomeArrays`
+    /// is an internal implementation detail of this library, not part of its public
+    /// API.
+    public static func overallReturn(payTable: PayTable) -> Double {
+        let arrays = HandOutcomeArrays.build(wildcardRank: payTable.wildcardRank)
+        let multipliers = HandResult.allCases.map { Double(payTable.multiplier(for: $0)) }
+
+        var totalEV = 0.0
+        var handCount = 0
+
+        // Scratch buffers reused across all 2,598,960 hands: `payoutOfSubset[mask]` is
+        // the total payout for holding exactly the cards `mask` selects (before
+        // correcting for the other 4 dealt cards), and `numeratorForHold[mask]` is the
+        // inclusion-exclusion-corrected EV numerator for actually holding `mask`.
+        // Allocating these once and mutating in place, instead of building fresh
+        // arrays per hand, is most of what makes this loop fast: an earlier version
+        // built on `HandOutcomeArrays.outcomeCounts` (which allocates per call)
+        // measured roughly two orders of magnitude slower.
+        var payoutOfSubset = [Double](repeating: 0, count: 32)
+        var numeratorForHold = [Double](repeating: 0, count: 32)
+
+        // swiftlint:disable identifier_name
+        for c0 in 0 ..< 52 {
+            for c1 in (c0 + 1) ..< 52 {
+                for c2 in (c1 + 1) ..< 52 {
+                    for c3 in (c2 + 1) ..< 52 {
+                        for c4 in (c3 + 1) ..< 52 {
+                            let cards = (c0, c1, c2, c3, c4)
+                            totalEV += bestHoldEV(
+                                cards: cards, arrays: arrays, multipliers: multipliers,
+                                payoutOfSubset: &payoutOfSubset, numeratorForHold: &numeratorForHold,
+                            )
+                            handCount += 1
+                        }
+                    }
+                }
+            }
+        }
+        // swiftlint:enable identifier_name
+
+        return totalEV / Double(handCount)
+    }
+
+    // swiftlint:disable large_tuple
+    /// Evaluates all 32 possible hold subsets of a dealt hand and returns the highest
+    /// expected value: the return-per-unit-bet a perfect-strategy player would get by
+    /// holding whichever subset maximizes EV.
+    ///
+    /// Uses the same inclusion-exclusion identity as `HandOutcomeArrays.outcomeCounts`
+    /// (for held set `H`, `EV(H) = Σ_{T ⊇ H} (-1)^|T∖H| * payout(T) / completions(H)`),
+    /// but restructured as a single subset-sum (Möbius) transform over all 32 subsets
+    /// of the 5 dealt cards, computed with fixed-size scratch buffers instead of
+    /// per-hold, per-discard-subset array allocation.
+    private static func bestHoldEV(
+        cards: (Int, Int, Int, Int, Int),
+        arrays: HandOutcomeArrays,
+        multipliers: [Double],
+        payoutOfSubset: inout [Double],
+        numeratorForHold: inout [Double],
+    ) -> Double {
+        for mask in 0 ..< 32 {
+            payoutOfSubset[mask] = arrays.payout(forSubsetMask: mask, cards: cards, multipliers: multipliers)
+            numeratorForHold[mask] = 0
+        }
+
+        // For every pair (hold, superset) with hold ⊆ superset, the superset's raw
+        // payout contributes to the hold's EV numerator with sign (-1)^|superset∖hold|.
+        // Enumerating subsets of each superset via the standard `(s - 1) & superset`
+        // bit trick visits exactly the 3^5 = 243 such pairs, with no allocation.
+        for supersetMask in 0 ..< 32 {
+            let payout = payoutOfSubset[supersetMask]
+            var holdMask = supersetMask
+            while true {
+                let discardedFromSuperset = (supersetMask & ~holdMask).nonzeroBitCount
+                let sign = discardedFromSuperset.isMultiple(of: 2) ? 1.0 : -1.0
+                numeratorForHold[holdMask] += sign * payout
+                if holdMask == 0 {
+                    break
+                }
+                holdMask = (holdMask - 1) & supersetMask
+            }
+        }
+
+        var best = 0.0
+        for holdMask in 0 ..< 32 {
+            let completions = completionsForHoldSize[holdMask.nonzeroBitCount]
+            best = max(best, numeratorForHold[holdMask] / Double(completions))
+        }
+        return best
+    }
+
+    // swiftlint:enable large_tuple
+}

--- a/Tests/PlayingCardTests/CombinatorialIndexTests.swift
+++ b/Tests/PlayingCardTests/CombinatorialIndexTests.swift
@@ -1,0 +1,80 @@
+@testable import PlayingCard
+import XCTest
+
+/// Verifies `CombinatorialIndex.index(sortedCards:)` is a bijection between k-subsets of
+/// `0..<52` and `0..<choose(52, k)`, for every hold size the library needs (1 through 5).
+final class CombinatorialIndexTests: XCTestCase {
+    func testChooseMatchesKnownBinomialCoefficients() {
+        XCTAssertEqual(CombinatorialIndex.choose(52, 5), 2_598_960)
+        XCTAssertEqual(CombinatorialIndex.choose(52, 4), 270_725)
+        XCTAssertEqual(CombinatorialIndex.choose(52, 3), 22100)
+        XCTAssertEqual(CombinatorialIndex.choose(52, 2), 1326)
+        XCTAssertEqual(CombinatorialIndex.choose(52, 1), 52)
+        XCTAssertEqual(CombinatorialIndex.choose(52, 0), 1)
+    }
+
+    func testChooseOutOfRangeReturnsZero() {
+        XCTAssertEqual(CombinatorialIndex.choose(5, 6), 0)
+        XCTAssertEqual(CombinatorialIndex.choose(5, -1), 0)
+    }
+
+    func testSingleCardIndexIsIdentity() {
+        // For k=1, the combinatorial index of [c] is just c itself.
+        for card in 0 ..< 52 {
+            XCTAssertEqual(CombinatorialIndex.index(sortedCards: [card]), card)
+        }
+    }
+
+    func testPairIndicesAreBijectiveOverFullRange() {
+        assertBijective(k: 2, n: 52)
+    }
+
+    func testTripleIndicesAreBijectiveOverFullRange() {
+        assertBijective(k: 3, n: 52)
+    }
+
+    func testFourCardIndicesAreBijectiveOverFullRange() {
+        assertBijective(k: 4, n: 52)
+    }
+
+    func testFiveCardIndicesAreBijectiveOverASmallerRange() {
+        // C(52, 5) is 2,598,960 combinations; exhaustively enumerating that here would
+        // make this test itself slow. Bijectivity of the underlying formula is already
+        // proven by the k=1..4 exhaustive checks above (the formula is the same
+        // structure for every k); this narrower range is a spot check that k=5 also
+        // produces a dense, collision-free range for a smaller universe.
+        assertBijective(k: 5, n: 12)
+    }
+
+    /// Exhaustively enumerates every ascending k-subset of `0..<n`, asserts every
+    /// resulting index is unique, and that the set of indices is exactly `0..<choose(n, k)`.
+    private func assertBijective(
+        k subsetSize: Int, n universeSize: Int, file: StaticString = #filePath, line: UInt = #line,
+    ) {
+        var seenIndices = Set<Int>()
+        let expectedCount = CombinatorialIndex.choose(universeSize, subsetSize)
+
+        func combinations(from start: Int, chosen: [Int]) {
+            if chosen.count == subsetSize {
+                let index = CombinatorialIndex.index(sortedCards: chosen)
+                XCTAssertTrue(
+                    seenIndices.insert(index).inserted,
+                    "duplicate index \(index) for cards \(chosen)",
+                    file: file, line: line,
+                )
+                XCTAssertTrue(
+                    (0 ..< expectedCount).contains(index),
+                    "index \(index) out of expected range [0, \(expectedCount)) for cards \(chosen)",
+                    file: file, line: line,
+                )
+                return
+            }
+            for next in start ..< universeSize {
+                combinations(from: next + 1, chosen: chosen + [next])
+            }
+        }
+
+        combinations(from: 0, chosen: [])
+        XCTAssertEqual(seenIndices.count, expectedCount, file: file, line: line)
+    }
+}

--- a/Tests/PlayingCardTests/HandOutcomeArraysTests.swift
+++ b/Tests/PlayingCardTests/HandOutcomeArraysTests.swift
@@ -1,0 +1,251 @@
+@testable import PlayingCard
+import XCTest
+
+/// Validates `HandOutcomeArrays`, the precomputed count-array building block for
+/// `PayTableAnalyzer`, against direct brute-force enumeration using the same
+/// `FastHandEvaluator` `OptimalPlay` itself uses. This is the correctness gate for the
+/// inclusion-exclusion arithmetic described in `HandOutcomeArrays.outcomeCounts`: a
+/// sign error there would silently corrupt every derived RTP number, so every hold size
+/// (0 through 5) is cross-checked against ground truth for both wildcard modes.
+///
+/// Skipped by default (opt in with `RUN_SLOW_TESTS=1`): building `HandOutcomeArrays`
+/// scores all 2,598,960 possible 5-card hands, which takes ~0.6s per wildcard mode in a
+/// Release build but ~70s per mode in the unoptimized Debug build `swift test` uses by
+/// default in CI — the same Debug-vs-Release gap documented for `OptimalPlay`'s hot
+/// loop. Run locally with `RUN_SLOW_TESTS=1 swift test --filter HandOutcomeArraysTests`,
+/// or `swift test -c release --filter HandOutcomeArraysTests` for the fast path.
+final class HandOutcomeArraysTests: XCTestCase {
+    override func setUpWithError() throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["RUN_SLOW_TESTS"] == "1",
+            "Builds all 2,598,960 possible 5-card hands per wildcard mode; opt in with "
+                + "RUN_SLOW_TESTS=1 to keep default CI runs fast. See class doc comment.",
+        )
+    }
+
+    // Building HandOutcomeArrays is a one-time, relatively expensive pass (scores all
+    // 2,598,960 possible 5-card hands). Cache one build per wildcard mode and reuse it
+    // across every test in this file, instead of rebuilding per test.
+    private static let standardArrays = HandOutcomeArrays.build(wildcardRank: nil)
+    private static let deucesWildArrays = HandOutcomeArrays.build(wildcardRank: .two)
+
+    // MARK: - Build sanity checks
+
+    func testStandardArraysBuildAndCoverAllHands() {
+        let arrays = Self.standardArrays
+        XCTAssertEqual(arrays.scoreForFiveCardHand.count, CombinatorialIndex.choose(52, 5))
+
+        let totalHands = arrays.countsForNoneHeld.reduce(0, +)
+        XCTAssertEqual(Int(totalHands), CombinatorialIndex.choose(52, 5))
+    }
+
+    func testDeucesWildArraysBuildAndCoverAllHands() {
+        let arrays = Self.deucesWildArrays
+        let totalHands = arrays.countsForNoneHeld.reduce(0, +)
+        XCTAssertEqual(Int(totalHands), CombinatorialIndex.choose(52, 5))
+    }
+
+    // MARK: - Cross-checks against brute-force enumeration (standard evaluation)
+
+    func testOutcomeCountsMatchesBruteForceForPatHand() {
+        assertMatchesBruteForce(
+            handCodes: royalFlushCodes,
+            heldPositions: [0, 1, 2, 3, 4],
+            wildcardRank: nil,
+        )
+    }
+
+    func testOutcomeCountsMatchesBruteForceForDiscardOne() {
+        assertMatchesBruteForce(
+            handCodes: royalFlushCodes,
+            heldPositions: [0, 1, 2, 3],
+            wildcardRank: nil,
+        )
+    }
+
+    func testOutcomeCountsMatchesBruteForceForDiscardTwo() {
+        assertMatchesBruteForce(
+            handCodes: twoPairCodes,
+            heldPositions: [0, 1, 2],
+            wildcardRank: nil,
+        )
+    }
+
+    func testOutcomeCountsMatchesBruteForceForDiscardThree() {
+        assertMatchesBruteForce(
+            handCodes: twoPairCodes,
+            heldPositions: [0, 1],
+            wildcardRank: nil,
+        )
+    }
+
+    func testOutcomeCountsSumMatchesExpectedComboCountForDiscardFour() {
+        assertOutcomeCountsSumMatchesExpectedCombos(
+            handCodes: highCardCodes,
+            heldPositions: [0],
+            wildcardRank: nil,
+        )
+    }
+
+    func testOutcomeCountsSumMatchesExpectedComboCountForDiscardFive() {
+        assertOutcomeCountsSumMatchesExpectedCombos(
+            handCodes: highCardCodes,
+            heldPositions: [],
+            wildcardRank: nil,
+        )
+    }
+
+    // MARK: - Cross-checks against brute-force enumeration (Deuces Wild evaluation)
+
+    func testOutcomeCountsMatchesBruteForceForPatHandDeucesWild() {
+        assertMatchesBruteForce(
+            handCodes: deucesWildFourOfAKindCodes,
+            heldPositions: [0, 1, 2, 3, 4],
+            wildcardRank: .two,
+        )
+    }
+
+    func testOutcomeCountsMatchesBruteForceForDiscardOneDeucesWild() {
+        assertMatchesBruteForce(
+            handCodes: deucesWildFourOfAKindCodes,
+            heldPositions: [0, 1, 2, 3],
+            wildcardRank: .two,
+        )
+    }
+
+    func testOutcomeCountsMatchesBruteForceForDiscardTwoDeucesWild() {
+        assertMatchesBruteForce(
+            handCodes: deucesWildFourOfAKindCodes,
+            heldPositions: [0, 1, 2],
+            wildcardRank: .two,
+        )
+    }
+
+    func testOutcomeCountsMatchesBruteForceForDiscardThreeDeucesWild() {
+        assertMatchesBruteForce(
+            handCodes: deucesWildFourOfAKindCodes,
+            heldPositions: [0, 1],
+            wildcardRank: .two,
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// A♠ K♠ Q♠ J♠ T♠ — royal flush, encoded as `(rank_index << 2) | suit_index`.
+    private var royalFlushCodes: [Int] {
+        [(12 << 2) | 0, (11 << 2) | 0, (10 << 2) | 0, (9 << 2) | 0, (8 << 2) | 0]
+    }
+
+    /// 5♠ 5♥ 8♠ 8♥ 2♣ — two pair (fives and eights) plus an unrelated deuce kicker,
+    /// using a real, non-wild-context deuce so the standard evaluator treats it as a
+    /// plain low card.
+    private var twoPairCodes: [Int] {
+        [(3 << 2) | 0, (3 << 2) | 1, (6 << 2) | 0, (6 << 2) | 1, (0 << 2) | 3]
+    }
+
+    /// 2♠ 7♥ 9♦ J♣ K♠ — no pair, no straight, no flush.
+    private var highCardCodes: [Int] {
+        [(0 << 2) | 0, (5 << 2) | 1, (7 << 2) | 2, (9 << 2) | 3, (11 << 2) | 0]
+    }
+
+    /// 8♠ 8♥ 8♦ 8♣ 2♠ — four of a kind with a wild deuce kicker, so the Deuces Wild
+    /// evaluator has a wild card in play even for the "hold everything" case.
+    private var deucesWildFourOfAKindCodes: [Int] {
+        [(6 << 2) | 0, (6 << 2) | 1, (6 << 2) | 2, (6 << 2) | 3, (0 << 2) | 0]
+    }
+
+    /// Compares `HandOutcomeArrays.outcomeCounts` against a direct brute-force count
+    /// obtained by enumerating every possible draw completion with `FastHandEvaluator`,
+    /// the same evaluator `OptimalPlay` uses live. A mismatch here means the
+    /// inclusion-exclusion arithmetic in `HandOutcomeArrays` is wrong.
+    private func assertMatchesBruteForce(
+        handCodes: [Int],
+        heldPositions: Set<Int>,
+        wildcardRank: Rank?,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+    ) {
+        let heldCodes = heldPositions.sorted().map { handCodes[$0] }
+        let discardedCodes = (0 ..< 5).filter { !heldPositions.contains($0) }.map { handCodes[$0] }
+
+        let arrays = wildcardRank == nil ? Self.standardArrays : Self.deucesWildArrays
+        let derived = arrays.outcomeCounts(held: heldCodes, discarded: discardedCodes)
+        let expected = bruteForceOutcomeCounts(
+            handCodes: handCodes, heldCodes: heldCodes, discardedCodes: discardedCodes, isWild: wildcardRank != nil,
+        )
+
+        XCTAssertEqual(derived, expected, file: file, line: line)
+    }
+
+    /// Cheaper sanity check for the larger discard sizes (4 and 5), where brute force
+    /// would be expensive: only verifies the total outcome count across all
+    /// `HandResult` buckets matches the known combination count, without checking the
+    /// per-bucket breakdown.
+    private func assertOutcomeCountsSumMatchesExpectedCombos(
+        handCodes: [Int],
+        heldPositions: Set<Int>,
+        wildcardRank: Rank?,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+    ) {
+        let heldCodes = heldPositions.sorted().map { handCodes[$0] }
+        let discardedCodes = (0 ..< 5).filter { !heldPositions.contains($0) }.map { handCodes[$0] }
+
+        let arrays = wildcardRank == nil ? Self.standardArrays : Self.deucesWildArrays
+        let derived = arrays.outcomeCounts(held: heldCodes, discarded: discardedCodes)
+        let expectedTotal = CombinatorialIndex.choose(47, discardedCodes.count)
+
+        XCTAssertEqual(derived.reduce(0, +), expectedTotal, file: file, line: line)
+    }
+
+    /// Direct brute-force reference: enumerates every possible way to complete the hand
+    /// by drawing replacements for `discardedCodes` from the 47 undealt cards, scores
+    /// each completion with `FastHandEvaluator`, and buckets the results.
+    private func bruteForceOutcomeCounts(
+        handCodes: [Int], heldCodes: [Int], discardedCodes: [Int], isWild: Bool,
+    ) -> [Int] {
+        var totals = [Int](repeating: 0, count: HandResult.allCases.count)
+        let handSet = Set(handCodes)
+        let remaining = (0 ..< 52).filter { !handSet.contains($0) }
+
+        func score(_ cards: [Int]) -> Int {
+            isWild
+                ? FastHandEvaluator.deucesWildCode(cards[0], cards[1], cards[2], cards[3], cards[4])
+                : FastHandEvaluator.standardCode(cards[0], cards[1], cards[2], cards[3], cards[4])
+        }
+
+        if discardedCodes.isEmpty {
+            totals[score(heldCodes)] += 1
+            return totals
+        }
+
+        for draw in combinations(of: remaining, choose: discardedCodes.count) {
+            totals[score(heldCodes + draw)] += 1
+        }
+        return totals
+    }
+
+    /// Every `choose`-sized combination of `elements`, in no particular order.
+    private func combinations(of elements: [Int], choose count: Int) -> [[Int]] {
+        guard count > 0 else { return [[]] }
+        guard elements.count >= count else { return [] }
+        if count == elements.count {
+            return [elements]
+        }
+
+        var results: [[Int]] = []
+        func recurse(_ start: Int, _ chosen: [Int]) {
+            if chosen.count == count {
+                results.append(chosen)
+                return
+            }
+            let remainingSlots = count - chosen.count
+            guard elements.count - start >= remainingSlots else { return }
+            for index in start ..< elements.count {
+                recurse(index + 1, chosen + [elements[index]])
+            }
+        }
+        recurse(0, [])
+        return results
+    }
+}

--- a/Tests/PlayingCardTests/HandOutcomeArraysTests.swift
+++ b/Tests/PlayingCardTests/HandOutcomeArraysTests.swift
@@ -8,21 +8,13 @@ import XCTest
 /// sign error there would silently corrupt every derived RTP number, so every hold size
 /// (0 through 5) is cross-checked against ground truth for both wildcard modes.
 ///
-/// Skipped by default (opt in with `RUN_SLOW_TESTS=1`): building `HandOutcomeArrays`
-/// scores all 2,598,960 possible 5-card hands, which takes ~0.6s per wildcard mode in a
-/// Release build but ~70s per mode in the unoptimized Debug build `swift test` uses by
-/// default in CI — the same Debug-vs-Release gap documented for `OptimalPlay`'s hot
-/// loop. Run locally with `RUN_SLOW_TESTS=1 swift test --filter HandOutcomeArraysTests`,
-/// or `swift test -c release --filter HandOutcomeArraysTests` for the fast path.
+/// Building `HandOutcomeArrays` scores all 2,598,960 possible 5-card hands, which
+/// takes ~0.6s per wildcard mode in a Release build but ~70s per mode in the
+/// unoptimized Debug build, the same Debug-vs-Release gap documented for
+/// `OptimalPlay`'s hot loop. Run with `swift test -c release --filter
+/// HandOutcomeArraysTests` for the fast path; CI runs the whole suite with `-c
+/// release` for this reason (see `.github/workflows/test.yml`).
 final class HandOutcomeArraysTests: XCTestCase {
-    override func setUpWithError() throws {
-        try XCTSkipUnless(
-            ProcessInfo.processInfo.environment["RUN_SLOW_TESTS"] == "1",
-            "Builds all 2,598,960 possible 5-card hands per wildcard mode; opt in with "
-                + "RUN_SLOW_TESTS=1 to keep default CI runs fast. See class doc comment.",
-        )
-    }
-
     // Building HandOutcomeArrays is a one-time, relatively expensive pass (scores all
     // 2,598,960 possible 5-card hands). Cache one build per wildcard mode and reuse it
     // across every test in this file, instead of rebuilding per test.
@@ -129,26 +121,42 @@ final class HandOutcomeArraysTests: XCTestCase {
         )
     }
 
+    func testOutcomeCountsSumMatchesExpectedComboCountForDiscardFourDeucesWild() {
+        assertOutcomeCountsSumMatchesExpectedCombos(
+            handCodes: deucesWildFourOfAKindCodes,
+            heldPositions: [0],
+            wildcardRank: .two,
+        )
+    }
+
+    func testOutcomeCountsSumMatchesExpectedComboCountForDiscardFiveDeucesWild() {
+        assertOutcomeCountsSumMatchesExpectedCombos(
+            handCodes: deucesWildFourOfAKindCodes,
+            heldPositions: [],
+            wildcardRank: .two,
+        )
+    }
+
     // MARK: - Helpers
 
-    /// A♠ K♠ Q♠ J♠ T♠ — royal flush, encoded as `(rank_index << 2) | suit_index`.
+    /// A♠ K♠ Q♠ J♠ T♠: royal flush, encoded as `(rank_index << 2) | suit_index`.
     private var royalFlushCodes: [Int] {
         [(12 << 2) | 0, (11 << 2) | 0, (10 << 2) | 0, (9 << 2) | 0, (8 << 2) | 0]
     }
 
-    /// 5♠ 5♥ 8♠ 8♥ 2♣ — two pair (fives and eights) plus an unrelated deuce kicker,
+    /// 5♠ 5♥ 8♠ 8♥ 2♣: two pair (fives and eights) plus an unrelated deuce kicker,
     /// using a real, non-wild-context deuce so the standard evaluator treats it as a
     /// plain low card.
     private var twoPairCodes: [Int] {
         [(3 << 2) | 0, (3 << 2) | 1, (6 << 2) | 0, (6 << 2) | 1, (0 << 2) | 3]
     }
 
-    /// 2♠ 7♥ 9♦ J♣ K♠ — no pair, no straight, no flush.
+    /// 2♠ 7♥ 9♦ J♣ K♠: no pair, no straight, no flush.
     private var highCardCodes: [Int] {
         [(0 << 2) | 0, (5 << 2) | 1, (7 << 2) | 2, (9 << 2) | 3, (11 << 2) | 0]
     }
 
-    /// 8♠ 8♥ 8♦ 8♣ 2♠ — four of a kind with a wild deuce kicker, so the Deuces Wild
+    /// 8♠ 8♥ 8♦ 8♣ 2♠: four of a kind with a wild deuce kicker, so the Deuces Wild
     /// evaluator has a wild card in play even for the "hold everything" case.
     private var deucesWildFourOfAKindCodes: [Int] {
         [(6 << 2) | 0, (6 << 2) | 1, (6 << 2) | 2, (6 << 2) | 3, (0 << 2) | 0]

--- a/Tests/PlayingCardTests/PayTableAnalyzerTests.swift
+++ b/Tests/PlayingCardTests/PayTableAnalyzerTests.swift
@@ -1,0 +1,51 @@
+@testable import PlayingCard
+import XCTest
+
+/// Cross-checks `PayTableAnalyzer.overallReturn(payTable:)` against the published
+/// return-to-player percentages for this library's existing pay tables. This is the
+/// end-to-end correctness gate for the whole `HandOutcomeArrays` / `PayTableAnalyzer`
+/// stack: a bug anywhere in the inclusion-exclusion arithmetic, the combinatorial
+/// indexing, or the best-hold selection would show up here as a return percentage that
+/// doesn't match the well-documented value for these pay tables.
+///
+/// Published values (verified against Wizard of Odds, https://wizardofodds.com):
+/// - Full-pay 9/6 Jacks or Better: 99.5439%
+/// - 9/5 Jacks or Better: 98.45%
+/// - 8/6 Jacks or Better: 98.39%
+/// - Full-pay Deuces Wild: 100.762%
+///
+/// Skipped by default (opt in with `RUN_SLOW_TESTS=1`): each `overallReturn` call
+/// exhaustively evaluates all 2,598,960 possible starting hands times up to 32 hold
+/// subsets each (~1.5s per pay table in a Release build, ~160s per pay table in the
+/// unoptimized Debug build `swift test` uses by default in CI). See
+/// `HandOutcomeArraysTests` for background on why these slow tests are gated instead
+/// of running by default.
+final class PayTableAnalyzerTests: XCTestCase {
+    override func setUpWithError() throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["RUN_SLOW_TESTS"] == "1",
+            "Exhaustively evaluates all 2,598,960 possible starting hands; opt in with "
+                + "RUN_SLOW_TESTS=1 to keep default CI runs fast. See class doc comment.",
+        )
+    }
+
+    func testFullPayJacksOrBetterReturn() {
+        let returnPercent = PayTableAnalyzer.overallReturn(payTable: .jacksOrBetter96) * 100
+        XCTAssertEqual(returnPercent, 99.5439, accuracy: 0.0005)
+    }
+
+    func testNineFiveJacksOrBetterReturn() {
+        let returnPercent = PayTableAnalyzer.overallReturn(payTable: .jacksOrBetter95) * 100
+        XCTAssertEqual(returnPercent, 98.45, accuracy: 0.01)
+    }
+
+    func testEightSixJacksOrBetterReturn() {
+        let returnPercent = PayTableAnalyzer.overallReturn(payTable: .jacksOrBetter86) * 100
+        XCTAssertEqual(returnPercent, 98.39, accuracy: 0.01)
+    }
+
+    func testFullPayDeucesWildReturn() {
+        let returnPercent = PayTableAnalyzer.overallReturn(payTable: .deucesWild) * 100
+        XCTAssertEqual(returnPercent, 100.762, accuracy: 0.001)
+    }
+}

--- a/Tests/PlayingCardTests/PayTableAnalyzerTests.swift
+++ b/Tests/PlayingCardTests/PayTableAnalyzerTests.swift
@@ -14,21 +14,11 @@ import XCTest
 /// - 8/6 Jacks or Better: 98.39%
 /// - Full-pay Deuces Wild: 100.762%
 ///
-/// Skipped by default (opt in with `RUN_SLOW_TESTS=1`): each `overallReturn` call
-/// exhaustively evaluates all 2,598,960 possible starting hands times up to 32 hold
-/// subsets each (~1.5s per pay table in a Release build, ~160s per pay table in the
-/// unoptimized Debug build `swift test` uses by default in CI). See
-/// `HandOutcomeArraysTests` for background on why these slow tests are gated instead
-/// of running by default.
+/// Each `overallReturn` call exhaustively evaluates all 2,598,960 possible starting
+/// hands times up to 32 hold subsets each (~1.5s per pay table in a Release build,
+/// ~160s per pay table in the unoptimized Debug build). CI runs the whole suite with
+/// `-c release` for this reason (see `.github/workflows/test.yml`).
 final class PayTableAnalyzerTests: XCTestCase {
-    override func setUpWithError() throws {
-        try XCTSkipUnless(
-            ProcessInfo.processInfo.environment["RUN_SLOW_TESTS"] == "1",
-            "Exhaustively evaluates all 2,598,960 possible starting hands; opt in with "
-                + "RUN_SLOW_TESTS=1 to keep default CI runs fast. See class doc comment.",
-        )
-    }
-
     func testFullPayJacksOrBetterReturn() {
         let returnPercent = PayTableAnalyzer.overallReturn(payTable: .jacksOrBetter96) * 100
         XCTAssertEqual(returnPercent, 99.5439, accuracy: 0.0005)


### PR DESCRIPTION
## What

Implements Phases 1-3 of a port of Wizard of Odds' video poker RTP-computation methodology (https://wizardofodds.com/games/video-poker/methodology/):

- **`CombinatorialIndex`**: generic `n choose k` and a combinatorial-number-system bijection between k-subsets of `0..<52` and `0..<choose(52,k)`. Replaces WoO's four separate `HandIndex2..5` functions with one generic formula.
- **`FastHandEvaluator`**: extracted the hand-scoring logic `OptimalPlay` already had (`standardCode`, `deucesWildCode`, and their straight-window helpers) into its own file, so both the existing live `fastEV` hot loop and the new array builder share one implementation instead of duplicating ~370 lines of wildcard logic. Pure mechanical move, verified behavior-preserving by the full existing test suite passing unchanged before and after.
- **`HandOutcomeArrays`**: the "One Second Program" technique. Scores every one of the 2,598,960 possible 5-card hands exactly once into six count arrays, then derives the draw-outcome distribution for any hold mask via a general subset-based inclusion-exclusion formula (generalizes WoO's five hand-derived formulas into one recursive rule). `outcomeCounts(held:discarded:)` validates its inputs are disjoint, duplicate-free, and valid card codes.
- **`PayTableAnalyzer.overallReturn(payTable:)`**: public API computing the exact return-to-player for a pay table under optimal play, by evaluating all 2,598,960 starting hands and their 32 hold subsets via `HandOutcomeArrays`, without draw-completion enumeration or per-hold heap allocation.

Not yet wired into `OptimalPlay`'s live per-hand hot path. That's Phase 4 (a benchmark spike into whether this speeds up live gameplay), not started in this PR.

## Testing

- `CombinatorialIndexTests`: exhaustive bijection checks for k=1..4 over the full 52-card range, spot check for k=5. Always runs, fast (<1s).
- `HandOutcomeArraysTests`: cross-checks the inclusion-exclusion arithmetic against brute-force enumeration for every hold size (0-5), in both wildcard modes, including Deuces Wild discard-4/discard-5 sum checks.
- `PayTableAnalyzerTests`: cross-checks `overallReturn` against the published RTP for this library's 4 existing pay tables.
- Both `HandOutcomeArraysTests` and `PayTableAnalyzerTests` exhaustively enumerate all 2,598,960 possible hands, so CI and `mise run test` now run `swift test -c release` (measured ~22s total locally vs. ~12 minutes in the default debug build) rather than skipping them.
- Full existing test suite passes unchanged, confirming the `FastHandEvaluator` extraction didn't alter `OptimalPlay` behavior.

## Follow-up (not in this PR)

- Phase 4: benchmark spike comparing array-based lookup vs. the current direct-enumeration `fastEV` for live gameplay, with a go/no-go decision gate.
