### PR TITLE
Fix DW0Two/DW0Three/DW0Four mislabeling mixed-suit holds as discard all

### DIFF
--- a/Sources/PlayingCard/StrategyPattern.swift
+++ b/Sources/PlayingCard/StrategyPattern.swift
@@ -736,8 +736,9 @@ public struct HoldClassifier {
         if case .onePair = classifyRankShape(ranks) {
             return .pair
         }
-        // Mixed suits, no pair, no suited straight/royal draw: describe by high-card
-        // count rather than collapsing to "discard all" — the player held 3 cards.
+        // No pair, and not a royal or straight-flush draw (whether same-suit or mixed):
+        // describe by high-card count rather than collapsing to "discard all" — the
+        // player held 3 cards.
         if ranks.allSatisfy({ $0 >= 10 }) {
             return .threeUnsuitedHighCards
         }
@@ -759,8 +760,8 @@ public struct HoldClassifier {
         if sameSuit, fv >= 11, sv >= 11 {
             return .twoToRoyalFlushJQHigh
         }
-        // Mixed pattern (not the royal-flush draw above), no pair: describe by
-        // high-card count rather than collapsing to "discard all".
+        // No pair, and not the suited J/Q-high royal-flush draw above (whether same-suit
+        // or mixed): describe by high-card count rather than collapsing to "discard all".
         if fv >= 11, sv >= 11 {
             return .twoUnsuitedHighCards
         }

--- a/Sources/PlayingCard/StrategyPattern.swift
+++ b/Sources/PlayingCard/StrategyPattern.swift
@@ -706,6 +706,15 @@ public struct HoldClassifier {
         if isInsideStraightDraw(sorted) {
             return .fourToInsideStraight
         }
+        // Mixed suits, no straight draw, no pair: describe by high-card count rather
+        // than collapsing to "discard all" — the player held 4 cards, not none.
+        let highCount = ranks.filter { $0 >= 11 }.count
+        if highCount >= 2 {
+            return .twoUnsuitedHighCards
+        }
+        if highCount == 1 {
+            return .oneHighCard
+        }
         return .discardAll
     }
 
@@ -727,7 +736,17 @@ public struct HoldClassifier {
         if case .onePair = classifyRankShape(ranks) {
             return .pair
         }
-        return .discardAll
+        // Mixed suits, no pair, no suited straight/royal draw: describe by high-card
+        // count rather than collapsing to "discard all" — the player held 3 cards.
+        if ranks.allSatisfy({ $0 >= 10 }) {
+            return .threeUnsuitedHighCards
+        }
+        let highRanks = ranks.filter { $0 >= 11 }
+        switch highRanks.count {
+        case 2: return .twoUnsuitedHighCards
+        case 1: return .oneHighCard
+        default: return .discardAll
+        }
     }
 
     private static func classifyDW0Two(_ first: PlayingCard, _ second: PlayingCard) -> StrategyPattern {
@@ -739,6 +758,14 @@ public struct HoldClassifier {
         // 2 to a royal flush, J/Q high (highest-rank 2-card hold in DW).
         if sameSuit, fv >= 11, sv >= 11 {
             return .twoToRoyalFlushJQHigh
+        }
+        // Mixed pattern (not the royal-flush draw above), no pair: describe by
+        // high-card count rather than collapsing to "discard all".
+        if fv >= 11, sv >= 11 {
+            return .twoUnsuitedHighCards
+        }
+        if fv >= 11 || sv >= 11 {
+            return .oneHighCard
         }
         return .discardAll
     }

--- a/Tests/PlayingCardTests/HoldClassifierDeucesWildTests.swift
+++ b/Tests/PlayingCardTests/HoldClassifierDeucesWildTests.swift
@@ -133,4 +133,282 @@ final class HoldClassifierDeucesWildTests: XCTestCase {
         let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3])
         XCTAssertEqual(pattern, .threeOfAKind)
     }
+
+    // MARK: - 0-deuce mixed-suit fallbacks (no pair, no flush/straight-flush draw)
+
+    func testDW0DeucesThreeHeldMixedSuitOneHighCardIsOneHighCard() {
+        // J♠ T♣ 9♥ held from a J-4-T-9-T deal: mixed suits, no pair, one card ranked J+.
+        let hand = [
+            card(.jack, .spades), card(.four, .hearts),
+            card(.ten, .clubs), card(.nine, .hearts), card(.ten, .diamonds),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 2, 3])
+        XCTAssertEqual(pattern, .oneHighCard)
+    }
+
+    func testDW0DeucesThreeHeldMixedSuitTwoHighCardsIsTwoUnsuitedHighCards() {
+        // J♠ Q♣ 4♥ held: mixed suits, no pair, two cards ranked J+.
+        let hand = [
+            card(.jack, .spades), card(.queen, .clubs), card(.four, .hearts),
+            card(.six, .diamonds), card(.eight, .clubs),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2])
+        XCTAssertEqual(pattern, .twoUnsuitedHighCards)
+    }
+
+    func testDW0DeucesThreeHeldMixedSuitAllRoyalIsThreeUnsuitedHighCards() {
+        // J♠ Q♣ A♥ held: mixed suits, no pair, all three in the royal set {T-A}.
+        let hand = [
+            card(.jack, .spades), card(.queen, .clubs), card(.ace, .hearts),
+            card(.six, .diamonds), card(.eight, .clubs),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2])
+        XCTAssertEqual(pattern, .threeUnsuitedHighCards)
+    }
+
+    func testDW0DeucesThreeHeldMixedSuitNoHighCardsIsDiscardAll() {
+        // 4♠ 6♣ 8♥ held: mixed suits, no pair, no card ranked J+.
+        let hand = [
+            card(.four, .spades), card(.six, .clubs), card(.eight, .hearts),
+            card(.jack, .diamonds), card(.queen, .clubs),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2])
+        XCTAssertEqual(pattern, .discardAll)
+    }
+
+    func testDW0DeucesFourHeldMixedSuitOneHighCardIsOneHighCard() {
+        // J♠ 4♣ 6♥ 8♦ held: mixed suits, no pair, no straight draw, one card ranked J+.
+        let hand = [
+            card(.jack, .spades), card(.four, .clubs),
+            card(.six, .hearts), card(.eight, .diamonds), card(.queen, .clubs),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3])
+        XCTAssertEqual(pattern, .oneHighCard)
+    }
+
+    func testDW0DeucesFourHeldMixedSuitTwoHighCardsIsTwoUnsuitedHighCards() {
+        // J♠ Q♣ 4♥ 6♦ held: mixed suits, no pair, no straight draw, two cards ranked J+.
+        let hand = [
+            card(.jack, .spades), card(.queen, .clubs),
+            card(.four, .hearts), card(.six, .diamonds), card(.eight, .clubs),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3])
+        XCTAssertEqual(pattern, .twoUnsuitedHighCards)
+    }
+
+    func testDW0DeucesFourHeldMixedSuitNoHighCardsIsDiscardAll() {
+        // 4♠ 6♣ 8♥ 3♦ held: mixed suits, no pair, no straight draw, no card ranked J+.
+        let hand = [
+            card(.four, .spades), card(.six, .clubs),
+            card(.eight, .hearts), card(.three, .diamonds), card(.queen, .clubs),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3])
+        XCTAssertEqual(pattern, .discardAll)
+    }
+
+    func testDW0DeucesTwoHeldMixedSuitOneHighCardIsOneHighCard() {
+        // J♠ 4♥ held: mixed suits, no pair, one card ranked J+.
+        let hand = [
+            card(.jack, .spades), card(.four, .hearts),
+            card(.six, .diamonds), card(.eight, .clubs), card(.nine, .clubs),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1])
+        XCTAssertEqual(pattern, .oneHighCard)
+    }
+
+    func testDW0DeucesTwoHeldUnsuitedHighCardsIsTwoUnsuitedHighCards() {
+        // J♠ Q♥ held: mixed suits, both cards ranked J+.
+        let hand = [
+            card(.jack, .spades), card(.queen, .hearts),
+            card(.six, .diamonds), card(.eight, .clubs), card(.nine, .clubs),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1])
+        XCTAssertEqual(pattern, .twoUnsuitedHighCards)
+    }
+
+    func testDW0DeucesTwoHeldMixedSuitNoHighCardsIsDiscardAll() {
+        // 4♠ 6♥ held: mixed suits, no pair, no card ranked J+.
+        let hand = [
+            card(.four, .spades), card(.six, .hearts),
+            card(.jack, .diamonds), card(.eight, .clubs), card(.nine, .clubs),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1])
+        XCTAssertEqual(pattern, .discardAll)
+    }
+
+    // MARK: - 2-deuce coverage (pat hand, royal/SF draws, base fallback)
+
+    func testDW2DeucesPatHandFiveOfAKindIsPatHandTwoDeuces() {
+        // 2♦ 2♥ K♣ K♠ K♦ held: 2 deuces + trip kings evaluates to five of a kind with wilds.
+        let hand = [
+            card(.two, .diamonds), card(.two, .hearts),
+            card(.king, .clubs), card(.king, .spades), card(.king, .diamonds),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3, 4])
+        XCTAssertEqual(pattern, .patHandTwoDeuces)
+    }
+
+    func testDW2DeucesOneRoyalNaturalIsFourToRoyalFlushTwoDeuces() {
+        // 2♦ 2♥ Q♣ held (3 cards): 1 royal natural completes 4 to a wild royal.
+        let hand = [
+            card(.two, .diamonds), card(.two, .hearts), card(.queen, .clubs),
+            card(.four, .spades), card(.six, .diamonds),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2])
+        XCTAssertEqual(pattern, .fourToRoyalFlushTwoDeuces)
+    }
+
+    func testDW2DeucesTwoRoyalNaturalsSameSuitIsFourToRoyalFlushTwoDeuces() {
+        // 2♦ 2♥ Q♣ K♣ held: 2 same-suit royal naturals complete 4 to a wild royal.
+        let hand = [
+            card(.two, .diamonds), card(.two, .hearts),
+            card(.queen, .clubs), card(.king, .clubs), card(.six, .diamonds),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3])
+        XCTAssertEqual(pattern, .fourToRoyalFlushTwoDeuces)
+    }
+
+    func testDW2DeucesAloneIsTwoDeuces() {
+        // 2♦ 2♥ held alone (no naturals) is the base two-deuces pattern.
+        let hand = [
+            card(.two, .diamonds), card(.two, .hearts),
+            card(.six, .clubs), card(.nine, .clubs), card(.king, .spades),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1])
+        XCTAssertEqual(pattern, .twoDeuces)
+    }
+
+    func testDW2DeucesOneLowNaturalFallsToTwoDeuces() {
+        // 2♦ 2♥ 4♣ held: the extra natural isn't royal, no better pattern than twoDeuces.
+        let hand = [
+            card(.two, .diamonds), card(.two, .hearts), card(.four, .clubs),
+            card(.nine, .clubs), card(.king, .spades),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2])
+        XCTAssertEqual(pattern, .twoDeuces)
+    }
+
+    func testDW2DeucesTwoRoyalNaturalsDifferentSuitsFallsToTwoDeuces() {
+        // 2♦ 2♥ Q♣ K♦ held: both royal but different suits, no wild-royal draw possible.
+        let hand = [
+            card(.two, .diamonds), card(.two, .hearts),
+            card(.queen, .clubs), card(.king, .diamonds), card(.six, .spades),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3])
+        XCTAssertEqual(pattern, .twoDeuces)
+    }
+
+    // MARK: - 1-deuce coverage (pat hand variants, royal/SF draws, base fallback)
+
+    func testDW1DeucePatFourOfAKindIsPatHandOneDeuce() {
+        // 2♦ K♣ K♠ K♦ 9♥ held: 1 deuce + trip kings evaluates to four of a kind with wild.
+        let hand = [
+            card(.two, .diamonds), card(.king, .clubs), card(.king, .spades),
+            card(.king, .diamonds), card(.nine, .hearts),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3, 4])
+        XCTAssertEqual(pattern, .patHandOneDeuce)
+    }
+
+    func testDW1DeucePatTwoPairIsPatFullHouseOneDeuce() {
+        // 2♦ K♣ K♠ 9♥ 9♦ held: 1 deuce + two natural pairs promotes to a full house.
+        let hand = [
+            card(.two, .diamonds), card(.king, .clubs), card(.king, .spades),
+            card(.nine, .hearts), card(.nine, .diamonds),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3, 4])
+        XCTAssertEqual(pattern, .patFullHouseOneDeuce)
+    }
+
+    func testDW1DeucePatOnePairIsPatLowHandOneDeuceThreeOfAKind() {
+        // 2♦ K♣ K♠ 6♥ 9♦ held: 1 deuce + one natural pair promotes to three of a kind.
+        let hand = [
+            card(.two, .diamonds), card(.king, .clubs), card(.king, .spades),
+            card(.six, .hearts), card(.nine, .diamonds),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3, 4])
+        XCTAssertEqual(pattern, .patLowHandOneDeuce)
+    }
+
+    func testDW1DeucePatStraightIsPatLowHandOneDeuce() {
+        // 2♦ 4♣ 5♥ 6♠ 8♦ held: 1 deuce completes a straight (4-5-6-2(as 7 or 3)-8... verified below).
+        let hand = [
+            card(.two, .diamonds), card(.four, .clubs), card(.five, .hearts),
+            card(.six, .spades), card(.eight, .diamonds),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3, 4])
+        XCTAssertEqual(pattern, .patLowHandOneDeuce)
+    }
+
+    func testDW1DeucePatFlushIsPatLowHandOneDeuce() {
+        // 2♦ 4♣ 7♣ 9♣ J♣ held: 1 deuce + four clubs is a flush with the deuce as itself or wild.
+        let hand = [
+            card(.two, .diamonds), card(.four, .clubs), card(.seven, .clubs),
+            card(.nine, .clubs), card(.jack, .clubs),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3, 4])
+        XCTAssertEqual(pattern, .patLowHandOneDeuce)
+    }
+
+    func testDW1DeucePatBelowThreeOfAKindFallsToOneDeuce() {
+        // 2♦ 3♣ 5♥ 8♠ 9♦ held: naturals have no pair; the deuce can only pair with the
+        // highest (9), which is below jacks-or-better, so the pat-hand switch doesn't
+        // match and this falls through to the base oneDeuce label.
+        let hand = [
+            card(.two, .diamonds), card(.three, .clubs), card(.five, .hearts),
+            card(.eight, .spades), card(.nine, .diamonds),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3, 4])
+        XCTAssertEqual(pattern, .oneDeuce)
+    }
+
+    func testDW1DeuceFourToRoyalFlushOneDeuce() {
+        // 2♦ J♣ Q♣ K♣ held (4 cards): 3 same-suit royal naturals + deuce = 4 to a wild royal.
+        let hand = [
+            card(.two, .diamonds), card(.jack, .clubs), card(.queen, .clubs),
+            card(.king, .clubs), card(.nine, .hearts),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3])
+        XCTAssertEqual(pattern, .fourToRoyalFlushOneDeuce)
+    }
+
+    func testDW1DeuceFourToStraightFlushOneDeuceLowThreshold() {
+        // 2♦ 3♣ 4♣ 5♣ held: consecutive naturals below rank 5 → not the "high" variant.
+        let hand = [
+            card(.two, .diamonds), card(.three, .clubs), card(.four, .clubs),
+            card(.five, .clubs), card(.nine, .hearts),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2, 3])
+        XCTAssertEqual(pattern, .fourToStraightFlushOneDeuce)
+    }
+
+    func testDW1DeuceThreeToRoyalFlushOneDeuce() {
+        // 2♦ Q♣ K♣ held (3 cards): 2 same-suit royal naturals + deuce = 3 to a wild royal.
+        let hand = [
+            card(.two, .diamonds), card(.queen, .clubs), card(.king, .clubs),
+            card(.nine, .hearts), card(.four, .spades),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2])
+        XCTAssertEqual(pattern, .threeToRoyalFlushOneDeuce)
+    }
+
+    func testDW1DeuceAloneIsOneDeuce() {
+        // 2♦ held alone (no naturals) is the base one-deuce pattern.
+        let hand = [
+            card(.two, .diamonds), card(.six, .clubs), card(.seven, .clubs),
+            card(.nine, .hearts), card(.four, .spades),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0])
+        XCTAssertEqual(pattern, .oneDeuce)
+    }
+
+    func testDW1DeuceOneLowNaturalFallsToOneDeuce() {
+        // 2♦ 6♣ held: single non-royal natural, no better pattern than oneDeuce.
+        let hand = [
+            card(.two, .diamonds), card(.six, .clubs), card(.seven, .clubs),
+            card(.nine, .hearts), card(.four, .spades),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1])
+        XCTAssertEqual(pattern, .oneDeuce)
+    }
 }


### PR DESCRIPTION
## Bug

`classifyDW0Two`, `classifyDW0Three`, and `classifyDW0Four` fell through to `.discardAll` for any 0-deuce mixed-suit hold with no pair and no flush/straight-flush draw, even when the player held 2-4 cards. This mislabeled e.g. J-T-9 (mixed suit, no pair) as "Discard all" in downstream coaching feedback, when cards were actually held.

## Fix

Add the same high-card-count fallback already used by the non-Deuces-Wild `classify()` equivalents (`classifyTwo`/`classifyThree`/`classifyFour`): mixed-suit, no-pair holds are now named by high-card count (`oneHighCard` / `twoUnsuitedHighCards` / `threeUnsuitedHighCards`) instead of collapsing to `discardAll`.

## Verification

Checked `classifyDW1Deuce` and `classifyDW2Deuces` for the same class of bug. They don't have it: their fallback labels (`.oneDeuce` / `.twoDeuces`) are accurate since a held deuce is never discarded, unlike the 0-deuce case. Added tests confirming every branch of both functions rather than assuming correctness.

## Tests

30 new tests in `HoldClassifierDeucesWildTests` (10 for the fix, 20 confirming the 1-/2-deuce paths). Full suite: 222 tests pass. Lint clean.
