### PR TITLE
Add PayTable.isWild(_:) helper

### DIFF
--- a/Sources/PlayingCard/PayTable.swift
+++ b/Sources/PlayingCard/PayTable.swift
@@ -339,6 +339,14 @@ public struct PayTable {
         HandResult.evaluate(cards: cards, wildcardRank: wildcardRank)
     }
 
+    /// Whether `card` acts as a wild card under this pay table.
+    ///
+    /// Always `false` for pay tables with no `wildcardRank` (e.g. Jacks or Better). For
+    /// Deuces Wild, returns `true` for any card ranked `.two` regardless of suit.
+    public func isWild(_ card: PlayingCard) -> Bool {
+        wildcardRank == card.rank
+    }
+
     /// Total coins returned for the given bet. `bet` must be 1-5.
     ///
     /// Royal flush (`.royalFlush` or `.naturalRoyalFlush`) pays 800x at bet=5 (4000 total)

--- a/Tests/PlayingCardTests/PayTableTests.swift
+++ b/Tests/PlayingCardTests/PayTableTests.swift
@@ -278,4 +278,27 @@ final class PayTableTests: XCTestCase {
         XCTAssertTrue(HandResult.jacksOrBetter.isWin)
         XCTAssertTrue(HandResult.royalFlush.isWin)
     }
+
+    // MARK: - isWild
+
+    func testIsWildTrueForWildcardRankUnderDeucesWild() {
+        let card = PlayingCard(rank: .two, suit: .hearts)
+        XCTAssertTrue(PayTable.deucesWild.isWild(card))
+    }
+
+    func testIsWildFalseForNonWildcardRankUnderDeucesWild() {
+        let card = PlayingCard(rank: .three, suit: .hearts)
+        XCTAssertFalse(PayTable.deucesWild.isWild(card))
+    }
+
+    func testIsWildFalseUnderJacksOrBetterEvenForRankTwo() {
+        // Jacks or Better has no wildcardRank, so a two is just a plain low card.
+        let card = PlayingCard(rank: .two, suit: .hearts)
+        XCTAssertFalse(PayTable.jacksOrBetter96.isWild(card))
+    }
+
+    func testIsWildIgnoresSuit() {
+        XCTAssertTrue(PayTable.deucesWild.isWild(PlayingCard(rank: .two, suit: .clubs)))
+        XCTAssertTrue(PayTable.deucesWild.isWild(PlayingCard(rank: .two, suit: .spades)))
+    }
 }


### PR DESCRIPTION
## Summary

Adds `PayTable.isWild(_:) -> Bool`, a single-card wild check. Previously, determining whether a specific dealt card is wild required comparing its rank against `PayTable.wildcardRank` manually at each call site in a host app. Since wildcard rules belong in this library, this centralizes that check here.

## Testing

- `mise run lint`: clean
- `mise run test`: all 72 Swift Testing tests + 28 `PayTableTests` (including 4 new `isWild` tests) pass
