### PR TITLE
Fix Deuces Wild 0-deuce three-to-straight-flush labeling

### DIFF
--- a/Sources/PlayingCard/StrategyPattern.swift
+++ b/Sources/PlayingCard/StrategyPattern.swift
@@ -117,6 +117,21 @@ public enum StrategyPattern: String, Equatable, CaseIterable, Sendable {
     case pair = "Pair"
     /// Two suited cards both J or higher (Deuces Wild 0-deuce position 10).
     case twoToRoyalFlushJQHigh = "Two to a royal flush (J/Q high)"
+    /// Zero-deuce, 3-card straight flush draw spanning 2 or 3 ranks (0 or 1 internal gaps),
+    /// e.g. suited 5-6-7 or suited 5-6-8. WoO's 0-deuce simple strategy splits 3-card straight
+    /// flush draws by rank spread, not by held high-card count: a single pair never pays in
+    /// Deuces Wild (the JoB "backup pair" rationale behind ``threeToStraightFlushType1``/
+    /// ``threeToStraightFlushType2``/``threeToStraightFlushType3`` doesn't apply here).
+    /// EV ~0.40–0.51, ranking below a low pair and four to a flush.
+    case threeToStraightFlushLowSpreadNoDeuce = "Three to a straight flush (spread 3-4, no deuce)"
+    /// Zero-deuce, 3-card straight flush draw spanning 4 ranks (2 internal gaps), e.g. suited
+    /// 5-7-9. The widest gap that can still complete a straight flush; weaker than
+    /// ``threeToStraightFlushLowSpreadNoDeuce``. EV ~0.30–0.36.
+    case threeToStraightFlushHighSpreadNoDeuce = "Three to a straight flush (spread 5, no deuce)"
+    /// Zero-deuce, 3-card ace-low straight flush draw (ace + two suited cards ranked 5 or
+    /// lower), e.g. suited A-2-4. Only completes toward a wheel (A-2-3-4-5), so per WoO this
+    /// is weaker than discarding everything and ranks last in the 0-deuce hierarchy.
+    case threeToStraightFlushAceLowNoDeuce = "Three to a straight flush (ace low, no deuce)"
 }
 
 // MARK: - HoldClassifier
@@ -730,7 +745,7 @@ public struct HoldClassifier {
                 return .threeToRoyalFlush
             }
             if canFormStraightFlush(ranks) {
-                return .threeToStraightFlushType1
+                return classifyDW0ThreeToStraightFlushSpread(ranks: ranks)
             }
         }
         if case .onePair = classifyRankShape(ranks) {
@@ -748,6 +763,31 @@ public struct HoldClassifier {
         case 1: return .oneHighCard
         default: return .discardAll
         }
+    }
+
+    /// Classifies a zero-deuce, 3-card suited straight flush draw by rank spread, per WoO's
+    /// Deuces Wild 0-deuce simple strategy. Unlike the Jacks-or-Better equivalent
+    /// (`classifyThreeToSFType`), this does not weigh held high-card count: a single pair
+    /// never pays in Deuces Wild, so there's no "backup pair" value to a held jack or queen.
+    ///
+    /// Called only when `canFormStraightFlush` already returned true.
+    private static func classifyDW0ThreeToStraightFlushSpread(ranks: [Int]) -> StrategyPattern {
+        let sorted = ranks.sorted()
+
+        // Ace-low: ace + two low cards (all ≤ 5) — only completes toward a wheel, per WoO
+        // this ranks below discarding everything.
+        if sorted.contains(14) {
+            let nonAce = sorted.filter { $0 != 14 }
+            if nonAce.allSatisfy({ $0 <= 5 }) {
+                return .threeToStraightFlushAceLowNoDeuce
+            }
+        }
+
+        // Number of interior gaps: for 3 cards, gapCount = span - 2.
+        let span = sorted.last! - sorted.first!
+        let gapCount = span - 2
+
+        return gapCount <= 1 ? .threeToStraightFlushLowSpreadNoDeuce : .threeToStraightFlushHighSpreadNoDeuce
     }
 
     private static func classifyDW0Two(_ first: PlayingCard, _ second: PlayingCard) -> StrategyPattern {

--- a/Tests/PlayingCardTests/HoldClassifierDeucesWildTests.swift
+++ b/Tests/PlayingCardTests/HoldClassifierDeucesWildTests.swift
@@ -411,4 +411,47 @@ final class HoldClassifierDeucesWildTests: XCTestCase {
         let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1])
         XCTAssertEqual(pattern, .oneDeuce)
     }
+
+    // MARK: - Zero-deuce, 3-card straight flush spread (spread 3-4 vs spread 5 vs ace-low)
+
+    func testDW0ThreeToSFConsecutiveIsLowSpread() {
+        // 5♣ 6♣ 7♣ held (consecutive, span 2, 0 gaps) + unrelated K♦ 9♥ kickers.
+        let hand = [
+            card(.five, .clubs), card(.six, .clubs), card(.seven, .clubs),
+            card(.king, .diamonds), card(.nine, .hearts),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2])
+        XCTAssertEqual(pattern, .threeToStraightFlushLowSpreadNoDeuce)
+    }
+
+    func testDW0ThreeToSFOneGapIsLowSpread() {
+        // 5♣ 6♣ 8♣ held (span 3, 1 gap) + unrelated K♦ 9♥ kickers.
+        let hand = [
+            card(.five, .clubs), card(.six, .clubs), card(.eight, .clubs),
+            card(.king, .diamonds), card(.nine, .hearts),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2])
+        XCTAssertEqual(pattern, .threeToStraightFlushLowSpreadNoDeuce)
+    }
+
+    func testDW0ThreeToSFTwoGapsIsHighSpread() {
+        // 5♣ 7♣ 9♣ held (span 4, 2 gaps) + unrelated K♦ 8♥ kickers.
+        let hand = [
+            card(.five, .clubs), card(.seven, .clubs), card(.nine, .clubs),
+            card(.king, .diamonds), card(.eight, .hearts),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2])
+        XCTAssertEqual(pattern, .threeToStraightFlushHighSpreadNoDeuce)
+    }
+
+    func testDW0ThreeToSFAceLowIsWorstTier() {
+        // A♣ 3♣ 4♣ held (wheel-only draw, no deuce since 2 is the wild card in this game)
+        // + unrelated K♦ 9♥ kickers.
+        let hand = [
+            card(.ace, .clubs), card(.three, .clubs), card(.four, .clubs),
+            card(.king, .diamonds), card(.nine, .hearts),
+        ]
+        let pattern = HoldClassifier.classifyDeucesWild(hand: hand, holding: [0, 1, 2])
+        XCTAssertEqual(pattern, .threeToStraightFlushAceLowNoDeuce)
+    }
 }


### PR DESCRIPTION
## Problem

\`classifyDW0Three\` unconditionally returned \`.threeToStraightFlushType1\` (a Jacks-or-Better label based on held high-card count) for any qualifying suited straight flush draw. That axis doesn't apply to Deuces Wild: a single pair never pays in this game, so there's no backup-pair rationale for weighing high cards, unlike Jacks or Better.

This only affects display/coaching labels. \`OptimalPlay.evaluate\` already brute-forces the actual hold decision via EV enumeration, independent of \`StrategyPattern\`, so this does not change any actual optimal-play decisions.

## Fix

Per Wizard of Odds' full-pay Deuces Wild optimal strategy chart, the 0-deuce three-to-straight-flush tier splits by rank spread instead:
- spread 3-4 (0-1 gaps) ranks above spread 5 (2 gaps)
- an ace-low draw (wheel-only) ranks below discarding everything

Adds three new cases: \`threeToStraightFlushLowSpreadNoDeuce\`, \`threeToStraightFlushHighSpreadNoDeuce\`, \`threeToStraightFlushAceLowNoDeuce\`, and rewrites \`classifyDW0Three\`'s straight flush branch to classify by spread using the same gap-count formula (\`span - 2\`) already used in \`classifyThreeToSFType\` for Jacks or Better.

## Testing

- 4 new tests in \`HoldClassifierDeucesWildTests.swift\` covering consecutive (0-gap), 1-gap, 2-gap, and ace-low draws.
- Full suite: 230 tests passing, 0 failures.
- Lint clean.