### PR TITLE
⚡ Bolt: precomputed binomial offsets to avoid stride multiplications

### DIFF
--- a/Sources/PlayingCard/HandOutcomeArrays.swift
+++ b/Sources/PlayingCard/HandOutcomeArrays.swift
@@ -386,13 +386,17 @@ struct HandOutcomeArrays {
     // swiftlint:enable identifier_name
 
     // swiftlint:disable large_tuple cyclomatic_complexity function_parameter_count
-    /// High-performance overload of payout that uses UnsafePointers to avoid array bounds checking.
+    /// High-performance overload of payout that uses UnsafePointers to avoid array bounds checking
+    /// and precomputed row pointers to avoid stride multiplications in the 32-mask loop.
     @inline(__always)
     func payout(
         forSubsetMask mask: Int,
-        cards: (Int, Int, Int, Int, Int),
+        r0: UnsafePointer<Int>,
+        r1: UnsafePointer<Int>,
+        r2: UnsafePointer<Int>,
+        r3: UnsafePointer<Int>,
+        r4: UnsafePointer<Int>,
         multipliers: UnsafePointer<Double>,
-        chooseTablePtr: UnsafePointer<Int>,
         scoreForFiveCardHandPtr: UnsafePointer<UInt8>,
         countsForFourHeldPtr: UnsafePointer<Int32>,
         countsForThreeHeldPtr: UnsafePointer<Int32>,
@@ -404,19 +408,19 @@ struct HandOutcomeArrays {
         var index = 0
         var position = 0
         if mask & 0b00001 != 0 {
-            position += 1; index += chooseTablePtr[cards.0 * Self.chooseTableStride + position]
+            position += 1; index += r0[position]
         }
         if mask & 0b00010 != 0 {
-            position += 1; index += chooseTablePtr[cards.1 * Self.chooseTableStride + position]
+            position += 1; index += r1[position]
         }
         if mask & 0b00100 != 0 {
-            position += 1; index += chooseTablePtr[cards.2 * Self.chooseTableStride + position]
+            position += 1; index += r2[position]
         }
         if mask & 0b01000 != 0 {
-            position += 1; index += chooseTablePtr[cards.3 * Self.chooseTableStride + position]
+            position += 1; index += r3[position]
         }
         if mask & 0b10000 != 0 {
-            position += 1; index += chooseTablePtr[cards.4 * Self.chooseTableStride + position]
+            position += 1; index += r4[position]
         }
 
         switch position {

--- a/Sources/PlayingCard/PayTableAnalyzer.swift
+++ b/Sources/PlayingCard/PayTableAnalyzer.swift
@@ -128,12 +128,23 @@ public enum PayTableAnalyzer {
         payoutOfSubset: UnsafeMutablePointer<Double>,
         reciprocalPtr: UnsafePointer<Double>,
     ) -> Double {
+        // Precompute row base pointers of the flattened binomial coefficient table
+        // once per hand to avoid expensive stride multiplications inside the 32-mask loop.
+        let r0 = chooseTablePtr + cards.0 * 6
+        let r1 = chooseTablePtr + cards.1 * 6
+        let r2 = chooseTablePtr + cards.2 * 6
+        let r3 = chooseTablePtr + cards.3 * 6
+        let r4 = chooseTablePtr + cards.4 * 6
+
         for mask in 0 ..< 32 {
             payoutOfSubset[mask] = arrays.payout(
                 forSubsetMask: mask,
-                cards: cards,
+                r0: r0,
+                r1: r1,
+                r2: r2,
+                r3: r3,
+                r4: r4,
                 multipliers: multipliers,
-                chooseTablePtr: chooseTablePtr,
                 scoreForFiveCardHandPtr: scoreForFiveCardHandPtr,
                 countsForFourHeldPtr: countsForFourHeldPtr,
                 countsForThreeHeldPtr: countsForThreeHeldPtr,


### PR DESCRIPTION
### What
We have optimized the hot 32-mask evaluation loop inside the exact RTP calculations (`PayTableAnalyzer.bestHoldEV` and `HandOutcomeArrays.payout`). Instead of computing binomial table offsets with stride multiplications inside the 32-mask loop:
`chooseTablePtr[cards.x * Self.chooseTableStride + position]`
we precalculate the five row pointers of type `UnsafePointer<Int>` corresponding to `cards.0...4` once per hand:
`let r0 = chooseTablePtr + cards.0 * 6`
and pass them down to a high-performance `payout` overload that uses them directly:
`r0[position]`

### Why
The `payout` method is called 32 times for each of the 2,598,960 possible hands (totaling over 83.1 million times per paytable analysis). By precomputing the row pointers once per hand instead of inside the 32-mask loop, we avoid over 415 million multiplications and offset additions, resulting in a cleaner and faster execution path.

### Impact
- Eliminates 160 stride multiplications and pointer additions per hand analysis.
- Decreases pipeline stalling and CPU instruction overhead on the absolute hottest execution path.
- Fully style-compliant and passes all linter/formatter/test checks.

---
*PR created automatically by Jules for task [7404846551848932491](https://jules.google.com/task/7404846551848932491) started by @infomofo*