### PR TITLE
⚡ Bolt: precompute binomial offsets once per hand in PayTableAnalyzer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,7 @@
 ## 2026-08-01 - Safe Hybrid Loop Unrolling
 **Learning:** Manually unrolling loops in performance-critical paths eliminates significant loop control, index calculation, and branch prediction overhead. However, hardcoding loop boundaries directly can introduce major maintainability and safety risks if data shapes change in the future. Implementing a hybrid approach, checking dynamically if the count matches the expected unrolled boundary size, running the fast path if true, and falling back to a clean dynamic loop otherwise, preserves maximum optimization while keeping the code flexible.
 **Action:** Always use a hybrid safe-path/fallback check when manually unrolling loops with non-constant bounds.
+
+## 2026-08-09 - Precomputing Row Pointers in Combinatorial Loops
+**Learning:** Performing stride multiplications and pointer offset additions (such as `cards.i * stride + position`) inside a highly frequent 32-mask loop within a 2,598,960-hand enumeration path incurs a large instruction overhead. Precomputing the row pointers (`chooseTablePtr + cards.i * stride`) once per hand (outside the 32-mask loop) completely eliminates the stride multiplications and address calculations inside the hot loop, yielding significant execution speedups.
+**Action:** Precalculate static base address offsets/row pointers outside highly frequent loops, passing them down as pre-offset raw pointers instead of calculating offsets dynamically inside the loops.

--- a/Sources/PlayingCard/HandOutcomeArrays.swift
+++ b/Sources/PlayingCard/HandOutcomeArrays.swift
@@ -386,13 +386,17 @@ struct HandOutcomeArrays {
     // swiftlint:enable identifier_name
 
     // swiftlint:disable large_tuple cyclomatic_complexity function_parameter_count
-    /// High-performance overload of payout that uses UnsafePointers to avoid array bounds checking.
+    /// High-performance overload of payout that uses UnsafePointers to avoid array bounds checking
+    /// and precomputed row pointers to avoid stride multiplications in the 32-mask loop.
     @inline(__always)
     func payout(
         forSubsetMask mask: Int,
-        cards: (Int, Int, Int, Int, Int),
+        r0: UnsafePointer<Int>,
+        r1: UnsafePointer<Int>,
+        r2: UnsafePointer<Int>,
+        r3: UnsafePointer<Int>,
+        r4: UnsafePointer<Int>,
         multipliers: UnsafePointer<Double>,
-        chooseTablePtr: UnsafePointer<Int>,
         scoreForFiveCardHandPtr: UnsafePointer<UInt8>,
         countsForFourHeldPtr: UnsafePointer<Int32>,
         countsForThreeHeldPtr: UnsafePointer<Int32>,
@@ -404,19 +408,19 @@ struct HandOutcomeArrays {
         var index = 0
         var position = 0
         if mask & 0b00001 != 0 {
-            position += 1; index += chooseTablePtr[cards.0 * Self.chooseTableStride + position]
+            position += 1; index += r0[position]
         }
         if mask & 0b00010 != 0 {
-            position += 1; index += chooseTablePtr[cards.1 * Self.chooseTableStride + position]
+            position += 1; index += r1[position]
         }
         if mask & 0b00100 != 0 {
-            position += 1; index += chooseTablePtr[cards.2 * Self.chooseTableStride + position]
+            position += 1; index += r2[position]
         }
         if mask & 0b01000 != 0 {
-            position += 1; index += chooseTablePtr[cards.3 * Self.chooseTableStride + position]
+            position += 1; index += r3[position]
         }
         if mask & 0b10000 != 0 {
-            position += 1; index += chooseTablePtr[cards.4 * Self.chooseTableStride + position]
+            position += 1; index += r4[position]
         }
 
         switch position {

--- a/Sources/PlayingCard/PayTableAnalyzer.swift
+++ b/Sources/PlayingCard/PayTableAnalyzer.swift
@@ -128,12 +128,23 @@ public enum PayTableAnalyzer {
         payoutOfSubset: UnsafeMutablePointer<Double>,
         reciprocalPtr: UnsafePointer<Double>,
     ) -> Double {
+        // Precompute row base pointers of the flattened binomial coefficient table
+        // once per hand to avoid expensive stride multiplications inside the 32-mask loop.
+        let r0 = chooseTablePtr + cards.0 * 6
+        let r1 = chooseTablePtr + cards.1 * 6
+        let r2 = chooseTablePtr + cards.2 * 6
+        let r3 = chooseTablePtr + cards.3 * 6
+        let r4 = chooseTablePtr + cards.4 * 6
+
         for mask in 0 ..< 32 {
             payoutOfSubset[mask] = arrays.payout(
                 forSubsetMask: mask,
-                cards: cards,
+                r0: r0,
+                r1: r1,
+                r2: r2,
+                r3: r3,
+                r4: r4,
                 multipliers: multipliers,
-                chooseTablePtr: chooseTablePtr,
                 scoreForFiveCardHandPtr: scoreForFiveCardHandPtr,
                 countsForFourHeldPtr: countsForFourHeldPtr,
                 countsForThreeHeldPtr: countsForThreeHeldPtr,


### PR DESCRIPTION
Precomputes binomial offset row base pointers once per hand instead of doing 160 stride multiplications and pointer additions inside the innermost 32-mask loop of HandOutcomeArrays.payout. This optimizes exact return-to-player (RTP) calculations without introducing any regressions or style violations. All tests and linters pass successfully.

---
*PR created automatically by Jules for task [1709434606275497582](https://jules.google.com/task/1709434606275497582) started by @infomofo*