### PR TITLE
⚡ Bolt: precompute card row pointers in PayTableAnalyzer to eliminate stride multiplications in hot loop

### DIFF
--- a/Sources/PlayingCard/HandOutcomeArrays.swift
+++ b/Sources/PlayingCard/HandOutcomeArrays.swift
@@ -18,7 +18,7 @@
 struct HandOutcomeArrays {
     /// Stride of the flattened choose table, matching `CombinatorialIndex`'s
     /// `maxK + 1` layout.
-    private static let chooseTableStride = 6
+    static let chooseTableStride = 6
 
     /// Number of distinct `HandResult` cases. Every count row has this many columns,
     /// indexed by `HandResult.rawValue`.
@@ -390,9 +390,14 @@ struct HandOutcomeArrays {
     @inline(__always)
     func payout(
         forSubsetMask mask: Int,
-        cards: (Int, Int, Int, Int, Int),
+        cardRows: (
+            UnsafePointer<Int>,
+            UnsafePointer<Int>,
+            UnsafePointer<Int>,
+            UnsafePointer<Int>,
+            UnsafePointer<Int>
+        ),
         multipliers: UnsafePointer<Double>,
-        chooseTablePtr: UnsafePointer<Int>,
         scoreForFiveCardHandPtr: UnsafePointer<UInt8>,
         countsForFourHeldPtr: UnsafePointer<Int32>,
         countsForThreeHeldPtr: UnsafePointer<Int32>,
@@ -404,19 +409,19 @@ struct HandOutcomeArrays {
         var index = 0
         var position = 0
         if mask & 0b00001 != 0 {
-            position += 1; index += chooseTablePtr[cards.0 * Self.chooseTableStride + position]
+            position += 1; index += cardRows.0[position]
         }
         if mask & 0b00010 != 0 {
-            position += 1; index += chooseTablePtr[cards.1 * Self.chooseTableStride + position]
+            position += 1; index += cardRows.1[position]
         }
         if mask & 0b00100 != 0 {
-            position += 1; index += chooseTablePtr[cards.2 * Self.chooseTableStride + position]
+            position += 1; index += cardRows.2[position]
         }
         if mask & 0b01000 != 0 {
-            position += 1; index += chooseTablePtr[cards.3 * Self.chooseTableStride + position]
+            position += 1; index += cardRows.3[position]
         }
         if mask & 0b10000 != 0 {
-            position += 1; index += chooseTablePtr[cards.4 * Self.chooseTableStride + position]
+            position += 1; index += cardRows.4[position]
         }
 
         switch position {

--- a/Sources/PlayingCard/PayTableAnalyzer.swift
+++ b/Sources/PlayingCard/PayTableAnalyzer.swift
@@ -69,17 +69,21 @@ public enum PayTableAnalyzer {
                     CombinatorialIndex.withChooseTablePointer { choosePtr in
                         arrays.withUnsafePointers { scorePtr, counts4Ptr, counts3Ptr, counts2Ptr, counts1Ptr, counts0Ptr in
                             // swiftlint:disable identifier_name
+                            let stride = HandOutcomeArrays.chooseTableStride
                             for c0 in 0 ..< 52 {
+                                let r0 = choosePtr + c0 * stride
                                 for c1 in (c0 + 1) ..< 52 {
+                                    let r1 = choosePtr + c1 * stride
                                     for c2 in (c1 + 1) ..< 52 {
+                                        let r2 = choosePtr + c2 * stride
                                         for c3 in (c2 + 1) ..< 52 {
+                                            let r3 = choosePtr + c3 * stride
                                             for c4 in (c3 + 1) ..< 52 {
-                                                let cards = (c0, c1, c2, c3, c4)
+                                                let r4 = choosePtr + c4 * stride
                                                 totalEV += bestHoldEV(
-                                                    cards: cards,
+                                                    cardRows: (r0, r1, r2, r3, r4),
                                                     arrays: arrays,
                                                     multipliers: multipliersPtr,
-                                                    chooseTablePtr: choosePtr,
                                                     scoreForFiveCardHandPtr: scorePtr,
                                                     countsForFourHeldPtr: counts4Ptr,
                                                     countsForThreeHeldPtr: counts3Ptr,
@@ -115,10 +119,15 @@ public enum PayTableAnalyzer {
     /// This reduces complexity from O(3^N) (243 loops) to O(N 2^N) (80 subtractions),
     /// completely bypassing the second scratch buffer and redundant writes.
     private static func bestHoldEV(
-        cards: (Int, Int, Int, Int, Int),
+        cardRows: (
+            UnsafePointer<Int>,
+            UnsafePointer<Int>,
+            UnsafePointer<Int>,
+            UnsafePointer<Int>,
+            UnsafePointer<Int>,
+        ),
         arrays: HandOutcomeArrays,
         multipliers: UnsafePointer<Double>,
-        chooseTablePtr: UnsafePointer<Int>,
         scoreForFiveCardHandPtr: UnsafePointer<UInt8>,
         countsForFourHeldPtr: UnsafePointer<Int32>,
         countsForThreeHeldPtr: UnsafePointer<Int32>,
@@ -131,9 +140,8 @@ public enum PayTableAnalyzer {
         for mask in 0 ..< 32 {
             payoutOfSubset[mask] = arrays.payout(
                 forSubsetMask: mask,
-                cards: cards,
+                cardRows: cardRows,
                 multipliers: multipliers,
-                chooseTablePtr: chooseTablePtr,
                 scoreForFiveCardHandPtr: scoreForFiveCardHandPtr,
                 countsForFourHeldPtr: countsForFourHeldPtr,
                 countsForThreeHeldPtr: countsForThreeHeldPtr,

--- a/Sources/PlayingCard/PayTableAnalyzer.swift
+++ b/Sources/PlayingCard/PayTableAnalyzer.swift
@@ -109,6 +109,7 @@ public enum PayTableAnalyzer {
         return totalEV / Double(handCount)
     }
 
+    // swiftformat:disable trailingCommas
     // swiftlint:disable large_tuple function_parameter_count
     /// Evaluates all 32 possible hold subsets of a dealt hand and returns the highest
     /// expected value: the return-per-unit-bet a perfect-strategy player would get by
@@ -124,7 +125,7 @@ public enum PayTableAnalyzer {
             UnsafePointer<Int>,
             UnsafePointer<Int>,
             UnsafePointer<Int>,
-            UnsafePointer<Int>,
+            UnsafePointer<Int>
         ),
         arrays: HandOutcomeArrays,
         multipliers: UnsafePointer<Double>,
@@ -173,5 +174,6 @@ public enum PayTableAnalyzer {
         return best
     }
 
+    // swiftformat:enable trailingCommas
     // swiftlint:enable large_tuple
 }


### PR DESCRIPTION
### 💡 What
Hoisted card row pointers `r0...r4` (`choosePtr + c0 * HandOutcomeArrays.chooseTableStride`, etc.) to their respective nested card loop levels (`c0...c4`) in `PayTableAnalyzer.swift`. Updated `HandOutcomeArrays.payout` to take pre-offset card row pointers `cardRows: (UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>)` instead of recomputing table strides for every mask iteration.

### 🎯 Why
In `PayTableAnalyzer`, `payout` is called 83,166,720 times per pay table evaluation (2,598,960 hands × 32 subset masks). Previously, calculating `chooseTablePtr[cards.i * chooseTableStride + position]` inside `payout` performed repeated integer multiplications (`cards.i * 6`) and pointer additions for every selected bitmask.

### 📊 Impact
Eliminates over 200 million redundant multiplication and address calculation instructions per pay table evaluation.

### 🔬 Verification
- `mise run lint` passed (prek git hooks, SwiftFormat, SwiftLint).
- `swift test -c release` passed all 222 tests cleanly.

---
*PR created automatically by Jules for task [8084864457338557826](https://jules.google.com/task/8084864457338557826) started by @infomofo*