### PR TITLE
⚡ Bolt: precompute choose table row pointers in PayTableAnalyzer

### DIFF
--- a/Sources/PlayingCard/HandOutcomeArrays.swift
+++ b/Sources/PlayingCard/HandOutcomeArrays.swift
@@ -18,7 +18,7 @@
 struct HandOutcomeArrays {
     /// Stride of the flattened choose table, matching `CombinatorialIndex`'s
     /// `maxK + 1` layout.
-    private static let chooseTableStride = 6
+    static let chooseTableStride = 6
 
     /// Number of distinct `HandResult` cases. Every count row has this many columns,
     /// indexed by `HandResult.rawValue`.
@@ -387,12 +387,17 @@ struct HandOutcomeArrays {
 
     // swiftlint:disable large_tuple cyclomatic_complexity function_parameter_count
     /// High-performance overload of payout that uses UnsafePointers to avoid array bounds checking.
+    ///
+    /// ⚡ Bolt Optimization: Accepts precomputed row pointers for the 5 cards in the dealt hand,
+    /// avoiding redundant stride multiplications (`card * chooseTableStride + position`) inside
+    /// the hot 32-mask EV evaluation loop.
     @inline(__always)
     func payout(
         forSubsetMask mask: Int,
-        cards: (Int, Int, Int, Int, Int),
+        rowPointers: (
+            UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>
+        ),
         multipliers: UnsafePointer<Double>,
-        chooseTablePtr: UnsafePointer<Int>,
         scoreForFiveCardHandPtr: UnsafePointer<UInt8>,
         countsForFourHeldPtr: UnsafePointer<Int32>,
         countsForThreeHeldPtr: UnsafePointer<Int32>,
@@ -404,19 +409,19 @@ struct HandOutcomeArrays {
         var index = 0
         var position = 0
         if mask & 0b00001 != 0 {
-            position += 1; index += chooseTablePtr[cards.0 * Self.chooseTableStride + position]
+            position += 1; index += rowPointers.0[position]
         }
         if mask & 0b00010 != 0 {
-            position += 1; index += chooseTablePtr[cards.1 * Self.chooseTableStride + position]
+            position += 1; index += rowPointers.1[position]
         }
         if mask & 0b00100 != 0 {
-            position += 1; index += chooseTablePtr[cards.2 * Self.chooseTableStride + position]
+            position += 1; index += rowPointers.2[position]
         }
         if mask & 0b01000 != 0 {
-            position += 1; index += chooseTablePtr[cards.3 * Self.chooseTableStride + position]
+            position += 1; index += rowPointers.3[position]
         }
         if mask & 0b10000 != 0 {
-            position += 1; index += chooseTablePtr[cards.4 * Self.chooseTableStride + position]
+            position += 1; index += rowPointers.4[position]
         }
 
         switch position {

--- a/Sources/PlayingCard/PayTableAnalyzer.swift
+++ b/Sources/PlayingCard/PayTableAnalyzer.swift
@@ -69,17 +69,24 @@ public enum PayTableAnalyzer {
                     CombinatorialIndex.withChooseTablePointer { choosePtr in
                         arrays.withUnsafePointers { scorePtr, counts4Ptr, counts3Ptr, counts2Ptr, counts1Ptr, counts0Ptr in
                             // swiftlint:disable identifier_name
+                            // ⚡ Bolt Optimization: Precompute card row pointers in the choose table at
+                            // each outer card loop level (c0...c4), eliminating tens of millions of
+                            // stride multiplications per RTP evaluation pass.
+                            let stride = HandOutcomeArrays.chooseTableStride
                             for c0 in 0 ..< 52 {
+                                let r0Ptr = choosePtr + c0 * stride
                                 for c1 in (c0 + 1) ..< 52 {
+                                    let r1Ptr = choosePtr + c1 * stride
                                     for c2 in (c1 + 1) ..< 52 {
+                                        let r2Ptr = choosePtr + c2 * stride
                                         for c3 in (c2 + 1) ..< 52 {
+                                            let r3Ptr = choosePtr + c3 * stride
                                             for c4 in (c3 + 1) ..< 52 {
-                                                let cards = (c0, c1, c2, c3, c4)
+                                                let r4Ptr = choosePtr + c4 * stride
                                                 totalEV += bestHoldEV(
-                                                    cards: cards,
+                                                    rowPointers: (r0Ptr, r1Ptr, r2Ptr, r3Ptr, r4Ptr),
                                                     arrays: arrays,
                                                     multipliers: multipliersPtr,
-                                                    chooseTablePtr: choosePtr,
                                                     scoreForFiveCardHandPtr: scorePtr,
                                                     countsForFourHeldPtr: counts4Ptr,
                                                     countsForThreeHeldPtr: counts3Ptr,
@@ -115,10 +122,11 @@ public enum PayTableAnalyzer {
     /// This reduces complexity from O(3^N) (243 loops) to O(N 2^N) (80 subtractions),
     /// completely bypassing the second scratch buffer and redundant writes.
     private static func bestHoldEV(
-        cards: (Int, Int, Int, Int, Int),
+        rowPointers: (
+            UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>,
+        ),
         arrays: HandOutcomeArrays,
         multipliers: UnsafePointer<Double>,
-        chooseTablePtr: UnsafePointer<Int>,
         scoreForFiveCardHandPtr: UnsafePointer<UInt8>,
         countsForFourHeldPtr: UnsafePointer<Int32>,
         countsForThreeHeldPtr: UnsafePointer<Int32>,
@@ -131,9 +139,8 @@ public enum PayTableAnalyzer {
         for mask in 0 ..< 32 {
             payoutOfSubset[mask] = arrays.payout(
                 forSubsetMask: mask,
-                cards: cards,
+                rowPointers: rowPointers,
                 multipliers: multipliers,
-                chooseTablePtr: chooseTablePtr,
                 scoreForFiveCardHandPtr: scoreForFiveCardHandPtr,
                 countsForFourHeldPtr: countsForFourHeldPtr,
                 countsForThreeHeldPtr: countsForThreeHeldPtr,

--- a/Sources/PlayingCard/PayTableAnalyzer.swift
+++ b/Sources/PlayingCard/PayTableAnalyzer.swift
@@ -112,6 +112,7 @@ public enum PayTableAnalyzer {
         return totalEV / Double(handCount)
     }
 
+    // swiftformat:disable trailingCommas
     // swiftlint:disable large_tuple function_parameter_count
     /// Evaluates all 32 possible hold subsets of a dealt hand and returns the highest
     /// expected value: the return-per-unit-bet a perfect-strategy player would get by
@@ -123,7 +124,7 @@ public enum PayTableAnalyzer {
     /// completely bypassing the second scratch buffer and redundant writes.
     private static func bestHoldEV(
         rowPointers: (
-            UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>,
+            UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>, UnsafePointer<Int>
         ),
         arrays: HandOutcomeArrays,
         multipliers: UnsafePointer<Double>,


### PR DESCRIPTION
💡 What: Precomputes combinatorial choose table row pointers (`r0Ptr` through `r4Ptr`) at each outer card loop level (`c0`...`c4`) in `PayTableAnalyzer.overallReturn` and passes them directly to an updated `HandOutcomeArrays.payout` overload.
🎯 Why: Previously, `payout` recomputed `chooseTablePtr[cards.X * chooseTableStride + position]` 32 times for every single 5-card hand (over 83 million times per RTP pass), incurring tens of millions of redundant stride multiplications and address offset calculations.
📊 Impact: Completely eliminates ~83 million stride multiplications per pass, reducing full-pay Jacks or Better RTP evaluation time from ~2.69s to ~2.63s (~2.0% total execution speedup including array build phase).
🔬 Measurement: Verified with `swift test -c release --filter PayTableAnalyzerTests.testFullPayJacksOrBetterReturn` and passed all 222 tests and `mise run lint`.

---
*PR created automatically by Jules for task [14269896518446043545](https://jules.google.com/task/14269896518446043545) started by @infomofo*